### PR TITLE
Handle arbitrary size bio requests by splitting them on pre-4.3.0 kernels

### DIFF
--- a/src/configure-tests/feature-tests/blk_queue_split.c
+++ b/src/configure-tests/feature-tests/blk_queue_split.c
@@ -1,0 +1,19 @@
+/*
+    Copyright (C) 2015 Datto Inc.
+
+    This file is part of dattobd.
+
+    This program is free software; you can redistribute it and/or modify it 
+    under the terms of the GNU General Public License version 2 as published
+    by the Free Software Foundation.
+*/
+
+#include "../../includes.h"
+
+static inline void dummy(void){
+	struct request_queue *q = NULL;
+	struct bio newbio;
+	struct bio *bioptr = &newbio;
+	struct bio_set *bs = NULL;
+	blk_queue_split(q, &bioptr, bs);
+}

--- a/src/configure-tests/feature-tests/bvec_gap_to_prev_3.c
+++ b/src/configure-tests/feature-tests/bvec_gap_to_prev_3.c
@@ -1,0 +1,18 @@
+/*
+    Copyright (C) 2015 Datto Inc.
+
+    This file is part of dattobd.
+
+    This program is free software; you can redistribute it and/or modify it 
+    under the terms of the GNU General Public License version 2 as published
+    by the Free Software Foundation.
+*/
+
+#include "../../includes.h"
+
+static inline void dummy(void){
+	struct request_queue q;
+	struct bio_vec bvec;
+	unsigned int offset = 0;
+	bvec_gap_to_prev(&q, &bvec, offset);
+}

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1848,11 +1848,8 @@ static struct bio *blk_bio_segment_split(struct request_queue *q,
 					 struct bio_set *bs)
 {
 	struct bio *split;
-	bio_iter_bvec_t bv, bvprv, *bvprvp = NULL;;
 	bio_iter_t iter;
 	unsigned seg_size = 0, nsegs = 0;
-
-	memset(bvprv, 0, sizeof(bio_iter_bvec_t));
 
 	struct bvec_merge_data bvm = {
 		.bi_bdev	= bio->bi_bdev,
@@ -1860,6 +1857,12 @@ static struct bio *blk_bio_segment_split(struct request_queue *q,
 		.bi_size	= 0,
 		.bi_rw		= bio->bi_rw,
 	};
+
+	bio_iter_bvec_t bv, bvprv, *bvprvp = NULL;;
+
+#ifdef HAVE_BVEC_ITER
+	memset(&bvprv, 0, sizeof(bio_iter_bvec_t));
+#endif
 
 	bio_for_each_segment(bv, bio, iter) {
 		if (q->merge_bvec_fn &&

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1874,8 +1874,13 @@ static struct bio *blk_bio_segment_split(struct request_queue *q,
 		 * If the queue doesn't support SG gaps and adding this
 		 * offset would create a gap, disallow it.
 		 */
+#ifndef HAVE_BVEC_GAP_TO_PREV_3
 		if (q->queue_flags & (1 << QUEUE_FLAG_SG_GAPS) &&
 		    prev && bvec_gap_to_prev(&bvprv, bv.bv_offset))
+#else
+		if (q->queue_flags & (1 << QUEUE_FLAG_SG_GAPS) &&
+		    prev && bvec_gap_to_prev(q, &bvprv, bv.bv_offset))
+#endif
 			goto split;
 
 		if (prev && blk_queue_cluster(q)) {

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1914,7 +1914,7 @@ split:
 	return split;
 }
 
-void bio_queue_split(struct request_queue *q, struct bio **bio,
+void blk_queue_split(struct request_queue *q, struct bio **bio,
 		     struct bio_set *bs)
 {
 	struct bio *split;

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1785,7 +1785,7 @@ static void tp_put(struct tracing_params *tp){
 
 /****************************BIO HELPER FUNCTIONS*****************************/
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0))
+#ifdef HAVE_BLK_QUEUE_SPLIT
 /* Patch port: block: make generic_make_request handle arbitrarily sized bios
 Ref: https://lwn.net/Articles/650246/ */
 static struct bio *snap_bio_discard_split(struct request_queue *q,
@@ -2561,7 +2561,7 @@ static int snap_mrf(struct request_queue *q, struct bio *bio){
 		return 0;
 	}
 
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0))
+#ifdef HAVE_BLK_QUEUE_SPLIT
 	struct bio_set *bio_split = bioset_create(BIO_POOL_SIZE, 0);
 	if (!bio_split)
 		return 0;

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1930,9 +1930,8 @@ void blk_queue_split(struct request_queue *q, struct bio **bio,
 		bio_chain(split, *bio);
 		generic_make_request(*bio);
 		*bio = split;
-	} else {
+	} else if (bs)
 		bioset_free(bs);
-	}
 }
 #endif
 
@@ -2548,9 +2547,6 @@ tracing_mrf_out:
 
 static int snap_mrf(struct request_queue *q, struct bio *bio){
 	struct snap_device *dev = q->queuedata;
-#ifndef HAVE_BLK_QUEUE_SPLIT
-	struct bio_set *bio_split = NULL;
-#endif
 
 	//if a write request somehow gets sent in, discard it
 	if(bio_data_dir(bio)){
@@ -2565,11 +2561,7 @@ static int snap_mrf(struct request_queue *q, struct bio *bio){
 	}
 
 #ifndef HAVE_BLK_QUEUE_SPLIT
-	bio_split = bioset_create(BIO_POOL_SIZE, 0);
-	if (!bio_split)
-		return 0;
-
-	blk_queue_split(q, &bio, bio_split);
+	blk_queue_split(q, &bio, NULL);
 #endif
 
 	//queue bio for processing by kernel thread
@@ -2610,9 +2602,6 @@ tracing_mrf_out:
 
 static void snap_mrf(struct request_queue *q, struct bio *bio){
 	struct snap_device *dev = q->queuedata;
-#ifndef HAVE_BLK_QUEUE_SPLIT
-	struct bio_set *bio_split = NULL;
-#endif
 	
 	//if a write request somehow gets sent in, discard it
 	if(bio_data_dir(bio)){
@@ -2627,11 +2616,7 @@ static void snap_mrf(struct request_queue *q, struct bio *bio){
 	}
 
 #ifndef HAVE_BLK_QUEUE_SPLIT
-	bio_split = bioset_create(BIO_POOL_SIZE, 0);
-	if (!bio_split)
-		return;
-
-	blk_queue_split(q, &bio, bio_split);
+	blk_queue_split(q, &bio, NULL);
 #endif
 
 	//queue bio for processing by kernel thread

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1785,6 +1785,157 @@ static void tp_put(struct tracing_params *tp){
 
 /****************************BIO HELPER FUNCTIONS*****************************/
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0))
+/* Patch port: block: make generic_make_request handle arbitrarily sized bios
+Ref: https://lwn.net/Articles/650246/ */
+static struct bio *snap_bio_discard_split(struct request_queue *q,
+					 struct bio *bio,
+					 struct bio_set *bs)
+{
+	unsigned int max_discard_sectors, granularity;
+	int alignment;
+	sector_t tmp;
+	unsigned split_sectors;
+
+	/* Zero-sector (unknown) and one-sector granularities are the same.  */
+	granularity = max(q->limits.discard_granularity >> 9, 1U);
+
+	max_discard_sectors = min(q->limits.max_discard_sectors, UINT_MAX >> 9);
+	max_discard_sectors -= max_discard_sectors % granularity;
+
+	if (unlikely(!max_discard_sectors)) {
+		/* XXX: warn */
+		return NULL;
+	}
+
+	if (bio_sectors(bio) <= max_discard_sectors)
+		return NULL;
+
+	split_sectors = max_discard_sectors;
+
+	/*
+	 * If the next starting sector would be misaligned, stop the discard at
+	 * the previous aligned sector.
+	 */
+	alignment = (q->limits.discard_alignment >> 9) % granularity;
+
+	tmp = bio->bi_iter.bi_sector + split_sectors - alignment;
+	tmp = sector_div(tmp, granularity);
+
+	if (split_sectors > tmp)
+		split_sectors -= tmp;
+
+	return bio_split(bio, split_sectors, GFP_NOIO, bs);
+}
+
+static struct bio *snap_bio_write_same_split(struct request_queue *q,
+					    struct bio *bio,
+					    struct bio_set *bs)
+{
+	if (!q->limits.max_write_same_sectors)
+		return NULL;
+
+	if (bio_sectors(bio) <= q->limits.max_write_same_sectors)
+		return NULL;
+
+	return bio_split(bio, q->limits.max_write_same_sectors, GFP_NOIO, bs);
+}
+
+static struct bio *snap_bio_segment_split(struct request_queue *q,
+					 struct bio *bio,
+					 struct bio_set *bs)
+{
+	struct bio *split;
+	struct bio_vec bv, bvprv;
+	struct bvec_iter iter;
+	unsigned seg_size = 0, nsegs = 0;
+	int prev = 0;
+
+	struct bvec_merge_data bvm = {
+		.bi_bdev	= bio->bi_bdev,
+		.bi_sector	= bio->bi_iter.bi_sector,
+		.bi_size	= 0,
+		.bi_rw		= bio->bi_rw,
+	};
+
+	bio_for_each_segment(bv, bio, iter) {
+		if (q->merge_bvec_fn &&
+		    q->merge_bvec_fn(q, &bvm, &bv) < (int) bv.bv_len)
+			goto split;
+
+		bvm.bi_size += bv.bv_len;
+
+		if (bvm.bi_size >> 9 > queue_max_sectors(q))
+			goto split;
+
+		/*
+		 * If the queue doesn't support SG gaps and adding this
+		 * offset would create a gap, disallow it.
+		 */
+		if (q->queue_flags & (1 << QUEUE_FLAG_SG_GAPS) &&
+		    prev && bvec_gap_to_prev(&bvprv, bv.bv_offset))
+			goto split;
+
+		if (prev && blk_queue_cluster(q)) {
+			if (seg_size + bv.bv_len > queue_max_segment_size(q))
+				goto new_segment;
+			if (!BIOVEC_PHYS_MERGEABLE(&bvprv, &bv))
+				goto new_segment;
+			if (!BIOVEC_SEG_BOUNDARY(q, &bvprv, &bv))
+				goto new_segment;
+
+			seg_size += bv.bv_len;
+			bvprv = bv;
+			prev = 1;
+			continue;
+		}
+new_segment:
+		if (nsegs == queue_max_segments(q))
+			goto split;
+
+		nsegs++;
+		bvprv = bv;
+		prev = 1;
+		seg_size = bv.bv_len;
+	}
+
+	return NULL;
+split:
+	split = bio_clone_bioset(bio, GFP_NOIO, bs);
+
+	split->bi_iter.bi_size -= iter.bi_size;
+	bio->bi_iter = iter;
+
+	if (bio_integrity(bio)) {
+		bio_integrity_advance(bio, split->bi_iter.bi_size);
+		bio_integrity_trim(split, 0, bio_sectors(split));
+	}
+
+	return split;
+}
+
+void snap_queue_split(struct request_queue *q, struct bio **bio,
+		     struct bio_set *bs)
+{
+	struct bio *split;
+
+	if ((*bio)->bi_rw & REQ_DISCARD)
+		split = snap_bio_discard_split(q, *bio, bs);
+	else if ((*bio)->bi_rw & REQ_WRITE_SAME)
+		split = snap_bio_write_same_split(q, *bio, bs);
+	else
+		split = snap_bio_segment_split(q, *bio, bs);
+
+	if (split) {
+		bio_chain(split, *bio);
+		generic_make_request(*bio);
+		*bio = split;
+	} else {
+		bioset_free(bs);
+	}
+}
+#endif
+
 static inline struct inode *page_get_inode(struct page *pg){
 	if(!pg->mapping) return NULL;
 	if((unsigned long)pg->mapping & PAGE_MAPPING_ANON) return NULL;
@@ -2409,7 +2560,15 @@ static int snap_mrf(struct request_queue *q, struct bio *bio){
 		bio_endio(bio, -EBUSY);
 		return 0;
 	}
-	
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0))
+	struct bio_set *bio_split = bioset_create(BIO_POOL_SIZE, 0);
+	if (!bio_split)
+		return 0;
+
+	snap_queue_split(q, &bio, bio_split);
+#endif
+
 	//queue bio for processing by kernel thread
 	bio_queue_add(&dev->sd_cow_bios, bio);
 	

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1848,8 +1848,8 @@ static struct bio *blk_bio_segment_split(struct request_queue *q,
 					 struct bio_set *bs)
 {
 	struct bio *split;
-	struct bio_vec bv, bvprv;
-	struct bvec_iter iter;
+	bio_iter_bvec_t bv, bvprv;
+	bio_iter_t iter;
 	unsigned seg_size = 0, nsegs = 0;
 	int prev = 0;
 

--- a/src/includes.h
+++ b/src/includes.h
@@ -20,4 +20,5 @@
 #include <linux/namei.h>
 #include <linux/unistd.h>
 #include <linux/vmalloc.h>
+#include <linux/version.h>
 #include <asm/div64.h>


### PR DESCRIPTION
Port mainline patch 54efd50bfd873e2dbf784e0b21a8027ba4299a3e:
block: make generic_make_request handle arbitrarily sized bios

Signed-off-by: Arun Prakash Jana <engineerarun@gmail.com>