### PR TITLE
removed setting the return code.

### DIFF
--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -718,7 +718,6 @@ static int file_io(struct file *filp, int is_write, void *buf, sector_t offset, 
 	set_fs(old_fs);
 	
 	if(ret != len){
-		ret = -EIO;
 		LOG_ERROR((int)ret, "error performing file '%s': - %llu, %lu", (is_write)? "write" : "read", (unsigned long long)offset, len);
 		return ret;
 	}


### PR DESCRIPTION
this error actually happened to somebody and the actual error code was
lost, so removing the assignment to ret will yield logging the actual
error code, make it easier to figure out what's going on.

I checked all other calls to LOG_ERROR and none seem to do anything similar
except calls to copy_from_user which doesn't return an error code.

I realize there isn't THAT much more coming back from vfs_read or vfs_write, but it's better than nothing.
