### PR TITLE
Bioset clones and small fixes

### DIFF
--- a/src/configure-tests/feature-tests/bio_bi_pool.c
+++ b/src/configure-tests/feature-tests/bio_bi_pool.c
@@ -1,0 +1,16 @@
+/*
+    Copyright (C) 2015 Datto Inc.
+
+    This file is part of dattobd.
+
+    This program is free software; you can redistribute it and/or modify it 
+    under the terms of the GNU General Public License version 2 as published
+    by the Free Software Foundation.
+*/
+
+#include "../../includes.h"
+
+static inline void dummy(void){
+	struct bio bio;
+	bio.bi_pool = NULL;
+}

--- a/src/configure-tests/feature-tests/merge_bvec_fn.c
+++ b/src/configure-tests/feature-tests/merge_bvec_fn.c
@@ -12,5 +12,5 @@
 
 static inline void dummy(void){
 	struct request_queue q;
-	q.merge_bvec_fn = NULL
+	q.merge_bvec_fn = NULL;
 }

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1886,7 +1886,7 @@ static int bio_make_read_clone(struct bio_set *bs, struct tracing_params *tp, st
 	new_bio = bio_alloc_bioset(GFP_NOIO, pages, bs);
 	if(!new_bio){
 		ret = -ENOMEM;
-		LOG_ERROR(ret, "error allocating bio clone - bs = %p", bs);
+		LOG_ERROR(ret, "error allocating bio clone - bs = %p, pages = %u", bs, pages);
 		goto bio_make_read_clone_error;
 	}
 	

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -2030,8 +2030,6 @@ static int snap_handle_write_bio(struct snap_device *dev, struct bio *bio){
 	char *data;
 	sector_t start_block, end_block = SECTOR_TO_BLOCK(bio_sector(bio));
 	
-	PRINT_BIO("snap_handle_write_bio", bio);
-	
 	//iterate through the bio and handle each segment (which is guaranteed to be block aligned)
 	bio_for_each_segment(bvec, bio, iter){		
 		//find the start and end block
@@ -2040,7 +2038,7 @@ static int snap_handle_write_bio(struct snap_device *dev, struct bio *bio){
 		
 		//map the page into kernel space
 		data = kmap(bio_iter_page(bio, iter));
-				
+		
 		//loop through the blocks in the page
 		for(; start_block < end_block; start_block++){
 			//pas the block to the cow manager to be handled
@@ -2307,8 +2305,6 @@ static int snap_trace_bio(struct snap_device *dev, struct bio *bio){
 	//if we don't need to cow this bio just call the real mrf normally
 	if(!bio_needs_cow(bio, dev->sd_cow_inode)) return dattobd_call_mrf(dev->sd_orig_mrf, bdev_get_queue(bio->bi_bdev), bio);
 	
-	PRINT_BIO("snap_trace_bio", bio);
-	
 	//the cow manager works in 4096 byte blocks, so read clones must also be 4096 byte aligned
 	start_sect = ROUND_DOWN(bio_sector(bio) - dev->sd_sect_off, SECTORS_PER_BLOCK) + dev->sd_sect_off;
 	end_sect = ROUND_UP(bio_sector(bio) + (bio_size(bio) / KERNEL_SECTOR_SIZE) - dev->sd_sect_off, SECTORS_PER_BLOCK) + dev->sd_sect_off;
@@ -2333,11 +2329,6 @@ retry:
 	tp->bio_sects[i].bio = new_bio;
 	tp->bio_sects[i].sect = bio_sector(new_bio);
 	tp->bio_sects[i].size = bio_size(new_bio);
-	
-	if(bytes / PAGE_SIZE < pages || i){
-		if(i == 0) PRINT_BIO("split orig bio", bio);
-		PRINT_BIO("\tclone bio", new_bio);
-	}
 	
 	//submit the bios
 	submit_bio(0, new_bio);
@@ -2370,8 +2361,6 @@ snap_trace_bio_error:
 static int inc_make_sset(struct snap_device *dev, sector_t sect, unsigned int len){
 	struct sector_set *sset;
 	
-	LOG_DEBUG("inc_trace_bio: sect = %llu size = %u", (unsigned long long)sect, len);
-		
 	//allocate sector set to hold record of change sectors
 	sset = kmalloc(sizeof(struct sector_set), GFP_NOIO);
 	if(!sset){

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1886,7 +1886,7 @@ static int bio_make_read_clone(struct bio_set *bs, struct tracing_params *tp, st
 	new_bio = bio_alloc_bioset(GFP_NOIO, pages, bs);
 	if(!new_bio){
 		ret = -ENOMEM;
-		LOG_ERROR(ret, "error allocating bio clone");
+		LOG_ERROR(ret, "error allocating bio clone - bs = %p", bs);
 		goto bio_make_read_clone_error;
 	}
 	
@@ -2330,7 +2330,7 @@ retry:
 	tp->bio_sects[i].sect = bio_sector(new_bio);
 	tp->bio_sects[i].size = bio_size(new_bio);
 	
-	if(bytes / PAGE_SIZE < pages){
+	if(bytes / PAGE_SIZE < pages || i){
 		if(i == 0) PRINT_BIO("split orig bio", bio);
 		PRINT_BIO("\tclone bio", new_bio);
 	}
@@ -2701,6 +2701,8 @@ static int __tracer_setup_base_dev(struct snap_device *dev, char *bdev_path){
 		dev->sd_size = get_capacity(dev->sd_base_dev->bd_disk);
 	}
 	
+	LOG_DEBUG("bdev size = %llu, offset = %llu", (unsigned long long)dev->sd_size, (unsigned long long)dev->sd_sect_off);
+	
 	return 0;
 	
 tracer_setup_base_dev_error:
@@ -2873,6 +2875,7 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor, stru
 	int ret;
 	
 	//allocate the bio_set
+	LOG_DEBUG("creating bioset");
 	dev->sd_bioset = bioset_create(BIO_SET_SIZE, 0);
 	if(!dev->sd_bioset){
 		ret = -ENOMEM;

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1880,10 +1880,10 @@ static int bio_make_read_clone(struct bio_set *bs, struct tracing_params *tp, st
 	int ret;
 	struct bio *new_bio;
 	struct page *pg;
-	unsigned int i, bytes, total = 0;
+	unsigned int i, bytes, total = 0, actual_pages = (pages > BIO_MAX_PAGES)? BIO_MAX_PAGES : pages;
 	
 	//allocate bio clone
-	new_bio = bio_alloc_bioset(GFP_NOIO, pages, bs);
+	new_bio = bio_alloc_bioset(GFP_NOIO, actual_pages, bs);
 	if(!new_bio){
 		ret = -ENOMEM;
 		LOG_ERROR(ret, "error allocating bio clone - bs = %p, pages = %u", bs, pages);
@@ -1904,7 +1904,7 @@ static int bio_make_read_clone(struct bio_set *bs, struct tracing_params *tp, st
 	bio_idx(new_bio) = 0;
 	
 	//fill the bio with pages
-	for(i = 0; i < pages; i++){
+	for(i = 0; i < actual_pages; i++){
 		//allocate a page and add it to our bio
 		pg = alloc_page(GFP_NOIO);
 		if(!pg){

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -2897,8 +2897,8 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor, stru
 	bdev_stack_limits(&dev->sd_queue->limits, bdev, 0);
 	
 #ifdef HAVE_MERGE_BVEC_FN
-	//we don't support request merging. if the underlying device does we can't send it requests that can be merged
-	if(bdev_get_queue(bdev)->merge_bvec_fn) blk_queue_max_hw_sectors(dev->sd_queue, PAGE_SIZE >> KERNEL_SECTOR_LOG_SIZE);
+	//use the same merge_bvec_fn as the base device
+	if(bdev_get_queue(bdev)->merge_bvec_fn) blk_queue_merge_bvec(dev->sd_queue, bdev_get_queue(bdev)->merge_bvec_fn);
 #endif
 	
 	//allocate a gendisk struct

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -317,6 +317,7 @@ static inline int dattobd_call_mrf(make_request_fn *fn, struct request_queue *q,
 #define UNVERIFIED 2
 
 //macros for working with bios
+#define BIO_SET_SIZE 256
 #define bio_flag(bio, flag) (bio->bi_flags |= (1 << flag))
 #define BIO_ALREADY_TRACED 20
 #define bio_last_sector(bio) (bio_sector(bio) + (bio_size(bio) / KERNEL_SECTOR_SIZE))
@@ -2866,7 +2867,7 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor, stru
 	int ret;
 	
 	//allocate the bio_set
-	dev->sd_bioset = bioset_create(BIO_POOL_SIZE, 0);
+	dev->sd_bioset = bioset_create(BIO_SET_SIZE, 0);
 	if(!dev->sd_bioset){
 		ret = -ENOMEM;
 		LOG_ERROR(ret, "error allocating bio set");

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -2030,6 +2030,8 @@ static int snap_handle_write_bio(struct snap_device *dev, struct bio *bio){
 	char *data;
 	sector_t start_block, end_block = SECTOR_TO_BLOCK(bio_sector(bio));
 	
+	PRINT_BIO("snap_handle_write_bio", bio);
+	
 	//iterate through the bio and handle each segment (which is guaranteed to be block aligned)
 	bio_for_each_segment(bvec, bio, iter){		
 		//find the start and end block
@@ -2305,6 +2307,8 @@ static int snap_trace_bio(struct snap_device *dev, struct bio *bio){
 	//if we don't need to cow this bio just call the real mrf normally
 	if(!bio_needs_cow(bio, dev->sd_cow_inode)) return dattobd_call_mrf(dev->sd_orig_mrf, bdev_get_queue(bio->bi_bdev), bio);
 	
+	PRINT_BIO("snap_trace_bio", bio);
+	
 	//the cow manager works in 4096 byte blocks, so read clones must also be 4096 byte aligned
 	start_sect = ROUND_DOWN(bio_sector(bio) - dev->sd_sect_off, SECTORS_PER_BLOCK) + dev->sd_sect_off;
 	end_sect = ROUND_UP(bio_sector(bio) + (bio_size(bio) / KERNEL_SECTOR_SIZE) - dev->sd_sect_off, SECTORS_PER_BLOCK) + dev->sd_sect_off;
@@ -2365,6 +2369,8 @@ snap_trace_bio_error:
 
 static int inc_make_sset(struct snap_device *dev, sector_t sect, unsigned int len){
 	struct sector_set *sset;
+	
+	LOG_DEBUG("inc_trace_bio: sect = %llu size = %u", (unsigned long long)sect, len);
 		
 	//allocate sector set to hold record of change sectors
 	sset = kmalloc(sizeof(struct sector_set), GFP_NOIO);


### PR DESCRIPTION
Read bio clones are now allocated from a bioset. merge_bvec_fn() feature now works properly and has been enhanced.