### PR TITLE
Merging in a few extra checks

### DIFF
--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1824,17 +1824,13 @@ static int tp_alloc(struct snap_device *dev, struct bio *bio, struct tracing_par
 }
 
 static void tp_get(struct tracing_params *tp){
-	LOG_DEBUG("getting tp: %p", tp);
 	atomic_inc(&tp->refs);
 }
 
 static void tp_put(struct tracing_params *tp){
-	LOG_DEBUG("putting tp: %p", tp);
-
 	//drop a reference to the tp
 	if(atomic_dec_and_test(&tp->refs)){
 		//if there are no references left, its safe to release the orig_bio
-		LOG_DEBUG("\tfreeing tp: %p", tp);
 		bio_queue_add(&tp->dev->sd_orig_bios, tp->orig_bio);
 		kfree(tp);
 	}

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1824,13 +1824,17 @@ static int tp_alloc(struct snap_device *dev, struct bio *bio, struct tracing_par
 }
 
 static void tp_get(struct tracing_params *tp){
+	LOG_DEBUG("getting tp: %p", tp);
 	atomic_inc(&tp->refs);
 }
 
 static void tp_put(struct tracing_params *tp){
+	LOG_DEBUG("putting tp: %p", tp);
+
 	//drop a reference to the tp
 	if(atomic_dec_and_test(&tp->refs)){
 		//if there are no references left, its safe to release the orig_bio
+		LOG_DEBUG("\tfreeing tp: %p", tp);
 		bio_queue_add(&tp->dev->sd_orig_bios, tp->orig_bio);
 		kfree(tp);
 	}
@@ -2265,6 +2269,12 @@ static void on_bio_read_complete(struct bio *bio){
 			bio_idx(bio) = 0;
 			break;
 		}
+	}
+
+	if(i == MAX_CLONES_PER_BIO){
+		ret = -EIO;
+		LOG_ERROR(ret, "clone not found in tp struct");
+		goto on_bio_read_complete_error;
 	}
 
 	for(i = 0; i < bio->bi_vcnt; i++){

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -424,6 +424,8 @@ struct snap_device{
 	struct bio_queue sd_orig_bios; //list of outstanding original bios
 	struct sset_queue sd_pending_ssets; //list of outstanding sector sets
 	struct bio_set *sd_bioset; //allocation pool for bios
+	atomic64_t sd_submitted_cnt; //count of read clones submitted to underlying driver
+	atomic64_t sd_received_cnt; //count of read clones submitted to underlying driver
 };
 
 static long ctrl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg);
@@ -2117,7 +2119,7 @@ static int snap_cow_thread(void *data){
 	//give this thread the highest priority we are allowed
 	set_user_nice(current, MIN_NICE);
 
-	while(!kthread_should_stop() || !bio_queue_empty(bq)) {
+	while(!kthread_should_stop() || !bio_queue_empty(bq) || atomic64_read(&dev->sd_submitted_cnt) != atomic64_read(&dev->sd_received_cnt)) {
 		//wait for a bio to process or a kthread_stop call
 		wait_event_interruptible(bq->event, kthread_should_stop() || !bio_queue_empty(bq));
 
@@ -2282,6 +2284,7 @@ static void on_bio_read_complete(struct bio *bio){
 
 	//queue cow bio for processing by kernel thread
 	bio_queue_add(&dev->sd_cow_bios, bio);
+	atomic64_inc(&dev->sd_received_cnt);
 	smp_wmb();
 
 	tp_put(tp);
@@ -2329,6 +2332,9 @@ retry:
 	tp->bio_sects[i].bio = new_bio;
 	tp->bio_sects[i].sect = bio_sector(new_bio);
 	tp->bio_sects[i].size = bio_size(new_bio);
+
+	atomic64_inc(&dev->sd_submitted_cnt);
+	smp_wmb();
 
 	//submit the bios
 	submit_bio(0, new_bio);
@@ -2476,7 +2482,7 @@ static int snap_merge_bvec(struct request_queue *q, struct bvec_merge_data *bvm,
 	struct request_queue *base_queue = bdev_get_queue(dev->sd_base_dev);
 
 	bvm->bi_bdev = dev->sd_base_dev;
-	
+
 	return base_queue->merge_bvec_fn(base_queue, bvm, bvec);
 }
 #endif
@@ -2959,6 +2965,9 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor, stru
 		LOG_ERROR(ret, "error starting mrf kernel thread");
 		goto tracer_setup_snap_error;
 	}
+
+	atomic64_set(&dev->sd_submitted_cnt, 0);
+	atomic64_set(&dev->sd_received_cnt, 0);
 
 	return 0;
 


### PR DESCRIPTION
added checks when destroying or transitioning snap_device to ensure all IO is complete.
added one more error check to on_bio_read_complete()