### PR TITLE
Ensure all error codes are correctly returned when using dbdctl

### DIFF
--- a/app/dbdctl.c
+++ b/app/dbdctl.c
@@ -337,5 +337,5 @@ int main(int argc, char **argv){
 	
 	if(ret)	perror("driver returned an error performing specified action. check dmesg for more info");
 	
-	return 0;
+	return ret;
 }


### PR DESCRIPTION
After experimenting with dbdctl, I discovered that dbdctl can fail and still return 0. Whilst I could parse the string for error messages, it would defeat the purpose of having a return code at all.

Signed-off-by: Chris Lapa <chris@cpdesign.com.au>