### PR TITLE
cosmetic: __exit should be used on kernel module exit function

### DIFF
--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -4362,7 +4362,7 @@ static int dattobd_proc_release(struct inode *inode, struct file *file){
 
 /************************MODULE SETUP AND DESTROY************************/
 
-static void agent_exit(void){
+static void __exit agent_exit(void){
 	int i;
 	struct snap_device *dev;
 	unsigned long cr0;


### PR DESCRIPTION
> The __exit macro causes the omission of the function when the module is built into the kernel, and like __exit, has no effect for loadable modules. Again, if you consider when the cleanup function runs, this makes complete sense; built-in drivers don't need a cleanup function, while loadable modules do.
[source](http://www.tldp.org/LDP/lkmpg/2.4/html/x281.htm)

This makes no difference for loadable kernel modules as stated, but may be useful if this ever gets looked at for mainline... 