### PR TITLE
Simplify CMakeLists.txt

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,31 +1,10 @@
-# cmake control file for libdattobd
-set(CMAKE_VERBOSE_MAKEFILE ON)
+cmake_minimum_required(VERSION 2.8.11)
 
-cmake_minimum_required(VERSION 2.8)
+project(dattobd C)
 
-SET(CMAKE_BUILD_TYPE Release)
+set(CMAKE_C_FLAGS "-std=gnu99 -Wall")
 
-IF(DEFINED CMAKE_BUILD_TYPE)
-   SET(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo")
-   MESSAGE ("Using existing build type.")
-ELSE()
-   SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo")
-   MESSAGE ("Setting build type.")
-ENDIF()
+set(src libdattobd.c)
 
-MESSAGE ("Build type: ${CMAKE_BUILD_TYPE}")
-
-project(dattobd)
-
-set(PROJECT_SOURCE_DIR ".")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "." )
-
-set(CMAKE_C_FLAGS_RELEASE "")
-
-include_directories(".")
-
-set (src libdattobd.c)
-
-# the binary itself
-add_library (dattobd STATIC ${src})
-
+add_library(dattobd STATIC ${src})
+target_include_directories(dattobd PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
- Use `target_include_directories` to make `libdattobd.h` available to users
- Bump minimum CMake version to 2.8.11 for `target_include_directories`
- Don't set the build type in the file (use `-DCMAKE_BUILD_TYPE`)
- Use consistent style for macros
