### PR TITLE
Fix compilation issues on 2.6.18-2.6.31

### DIFF
--- a/src/configure-tests/feature-tests/fops_fallocate.c
+++ b/src/configure-tests/feature-tests/fops_fallocate.c
@@ -1,0 +1,16 @@
+/*
+    Copyright (C) 2015 Datto Inc.
+
+    This file is part of dattobd.
+
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License version 2 as published
+    by the Free Software Foundation.
+*/
+
+#include "../../includes.h"
+
+static inline void dummy(void){
+	struct file f = { .f_version = 0 };
+	f.f_op->fallocate(&f, 0, 0, 0);
+}


### PR DESCRIPTION
Fix compilation issues on 2.6.18-2.6.31
* Add configure test to explicitly check for `fallocate` in `struct file_operations`
* Add and use a `dattobd_get_nd_mnt` macro
* Define `ACCESS_ONCE` if it is not already
* `bdev_stack_limits`: pass the limits to `blk_stack_limits`, not the request (really fix compiling on 2.6.31)
* `real_fallocate`: add case if both `struct inode` and `struct file` don't have `fallocate`

Note about using `HAVE_PATH_PUT` to detect version 2.6.25:
* `struct nameidata` changed to use `struct path` in 2.6.25
* `d_path` changed to use `struct path` in 2.6.25

Does not compile on:
* Fedora Core 6 (2.6.18-1.2798.fc6)
* Fedora Core 7 (2.6.21-1.3194.fc7)
* Fedora Core 8 (2.6.23.1-42.fc8)

```
/root/dattobd/src/dattobd.c: In function ‘agent_init’:
/root/dattobd/src/dattobd.c:4835: error: implicit declaration of function ‘proc_create’
/root/dattobd/src/dattobd.c:4835: warning: assignment makes pointer from integer without a cast
```

`proc_create` was not exported until 2.6.25

Compiles on:
* Fedora Core 9 (2.6.25-14.fc9.x86_64)
* Fedora Core 10 (2.6.27.41-170.2.117.fc10.x86_64)
* Fedora Core 11 (2.6.29.4-167.fc11.x86_64)
* Fedora Core 12 (2.6.31.5-127.fc12.x86_64)
* Fedora Core 14 (2.6.35.14-106.fc14.x86_64)
* Fedora 21 (4.1.13-100.fc21.x86_64)
* CentOS 5 (2.6.18-416.el5)
* CentOS 6 (2.6.32-642.11.1.el6.x86_64)
* CentOS 7 (3.10.0-327.36.3.el7.x86_64)
* Ubuntu 14.04 (3.16.0-77-generic)