### PR TITLE
Add simple test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Module.symvers
 
 # Leftover files
 *~
+tests/results

--- a/tests/dbdtest.sh
+++ b/tests/dbdtest.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+export TEST_DIR="$(cd ${0%/*} && pwd)"
+
+source ${TEST_DIR}/include/common.sh
+
+init_env
+
+[[ -x "${DBDCTL}" ]] || exit 127
+[[ -x "${UPDATE_IMG}" ]] || exit 127
+
+TESTS=0
+FAILED=0
+SKIPPED=0
+
+function find_tests
+{
+    [[ -z "$1" ]] && return 1
+
+    find "$1" -type f -name "*.sh"
+}
+
+function run_test
+{
+    (( TESTS += 1 ))
+    echo -e "\n[TEST] $1" >> results
+
+    bash "$@" 2>&1 >> results
+    local ret=$?
+
+    if [[ "${ret}" == "0" ]]; then
+        str="[PASS] $1"
+        echo -e "\033[0;32m${str}\033[0m"
+    elif [[ "${ret}" == "1" ]]; then
+        (( FAILED += 1 ))
+        str="[FAIL] $1"
+        echo -e "\033[0;31m${str}\033[0m"
+    elif [[ "${ret}" == "2" ]]; then
+        (( SKIPPED += 1 ))
+        str="[SKIP] $1"
+        echo -e "\033[1;33m${str}\033[0m"
+    fi
+
+    echo "${str}" >> results
+
+    return ${ret}
+}
+
+
+if [[ "$EUID" != "0" ]]; then
+    echo "Must be run as root"
+    exit 1
+fi
+
+>| results
+echo "dattobd: $(git rev-parse --short HEAD)" | tee -a results
+echo "kernel: $(uname -r)" | tee -a results
+echo "gcc: $(gcc --version | awk 'NR==1 { print $3 }')" | tee -a results
+echo "bash: ${BASH_VERSION}" | tee -a results
+echo
+
+setup_default_device || {
+    echo "Failed to setup the default device" 1>&2
+    exit 1
+}
+
+insert_module || exit 1
+
+ts=($(find_tests "${TEST_DIR}/scripts"))
+
+for t in ${ts[@]}; do
+    run_test $t
+done
+
+remove_module
+cleanup_default_device
+
+echo -e "\n${TESTS} tests executed (${FAILED} failed, ${SKIPPED} skipped)" | tee -a results
+[[ "${FAILED}" == "0" ]] || exit 1
+exit 0

--- a/tests/include/common.sh
+++ b/tests/include/common.sh
@@ -1,0 +1,209 @@
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+# Initialize environment variables
+function init_env
+{
+    DBDCTL="${TEST_DIR}/../app/dbdctl"
+    UPDATE_IMG="${TEST_DIR}/../utils/update-img"
+    KMOD="dattobd.ko"
+    KMOD_PATH="${TEST_DIR}/../src/${KMOD}"
+    DEV_DIR="/var/tmp/dattobd/dev"
+    MOUNT_DIR="/var/tmp/dattobd/mnt"
+    DISK="${DEV_DIR}/disk0"
+    DEVICE="/dev/loop4"
+    MOUNT="${MOUNT_DIR}/dev0"
+    COW_FILE="cow.snap"
+    MINOR=1
+}
+
+function insert_module
+{
+    insmod ${KMOD_PATH} $@ && return 0
+
+    echo "Unable to load module" >&2
+    return 1
+}
+
+function remove_module
+{
+    rmmod ${KMOD} && return 0
+
+    echo "Unable to remove module" >&2
+    return 1
+}
+
+function is_mounted
+{
+    grep -qw "$1" /proc/mounts
+}
+
+function is_tracked
+{
+    grep -q "\"minor\": $1," /proc/datto-info
+}
+
+function md5
+{
+    [[ -e "$1" ]] || return 1
+    md5sum "$1" | awk '{ print $1 }' || return 1
+    return 0
+}
+
+# parse <minor> <field>
+# Prints the value of the field for a given minor if it exists.
+# Returns 0 on success, 1 otherwise.
+#
+function parse
+{
+    [[ "$#" == "2" ]] || return 1
+    [[ -f "/proc/datto-info" ]] || return 1
+
+    python2.7 ${TEST_DIR}/parse.py "$1" "$2"
+}
+
+# create_device <file> <size>
+# Create a file of a given size in MiB.
+# Returns 0 on success and 1 on error.
+#
+function create_device
+{
+    [[ "$#" == "2" ]] || return 1
+
+    local file="$1"
+    local size="$2"
+
+    local dir=$(dirname $file)
+    mkdir -p "${dir}" || return 1
+
+    if command -v fallocate &> /dev/null; then
+        fallocate -l ${size}M "${file}" || return 1
+    elif command -v truncate &> /dev/null; then
+        truncate --size=${size}M "${file}" || return 1
+    else
+        dd if=/dev/zero of="${file}" bs=1M count=${size} || return 1
+    fi
+
+    sync
+    sleep 0.1
+    return 0
+}
+
+# format_device <device> <fs>
+# Format a device with the given file system type.
+# Returns 0 on success and 1 on error.
+#
+function format_device
+{
+    [[ "$#" == "2" ]] || return 1
+
+    local dev="$1"
+    local fs="$2"
+
+    case "${fs}" in
+        ext[2-4])
+            mkfs.${fs} -F "${dev}" || return 1
+            ;;
+        fat|fat32|FAT|FAT32)
+            mkfs.vfat -F 32 "${dev}" || return 1
+            ;;
+        ntfs|NTFS)
+            mkfs.ntfs -F -f "${dev}" || return 1
+            ;;
+        xfs|XFS)
+            mkfs.xfs -f "${dev}" || return 1
+            ;;
+        *)
+            echo "Invalid file system type ${fs} given" >&2
+            return 1
+            ;;
+    esac
+
+    sync
+    sleep 0.1
+    return 0
+}
+
+# setup_device <file> <size> <fs> <loop> <mount>
+# Create, format, and mount a loop device.
+# Returns 0 on success and 1 on error.
+#
+function setup_device
+{
+    [[ "$#" == "5" ]] || return 1
+
+    local file="$1"
+    local size="$2"
+    local fs="$3"
+    local loop="$4"
+    local mount="$5"
+
+    create_device "${file}" ${size} || return 1
+    format_device "${file}" ${fs} || return 1
+
+    losetup ${loop} "${file}" || return 1
+    sleep 0.1
+
+    mkdir -p ${mount} || return 1
+    mount ${loop} ${mount} || return 1
+    sleep 0.1
+
+    return 0
+}
+
+function setup_default_device
+{
+    if command -v mkfs.ext4 &> /dev/null; then
+        setup_device ${DISK} 512 ext4 ${DEVICE} ${MOUNT}
+    else
+        setup_device ${DISK} 512 ext3 ${DEVICE} ${MOUNT}
+    fi
+}
+
+# cleanup_device <file> <loop> <mount>
+# Unmount and destroy a loop device and its backing file.
+# Returns 0 on success and 1 on error.
+#
+function cleanup_device
+{
+    [[ "$#" == "3" ]] || return 1
+
+    local file="$1"
+    local loop="$2"
+    local mount="$3"
+
+    if is_mounted ${loop}; then
+        umount ${mount} || return 1
+    fi
+
+    sleep 0.1
+
+    if losetup ${loop} &> /dev/null; then
+        losetup -d ${loop} || return 1
+    fi
+
+    sleep 0.1
+
+    rm -f ${file} || return 1
+    sync
+
+    sleep 0.1
+    return 0
+}
+
+function cleanup_default_device
+{
+    cleanup_device ${DISK} ${DEVICE} ${MOUNT}
+}

--- a/tests/include/libtest.sh
+++ b/tests/include/libtest.sh
@@ -1,0 +1,82 @@
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+function atexit
+{
+    _CLEANUP="$@"
+}
+
+function _exit
+{
+    if [[ -n "${_CLEANUP}" ]]; then
+        local cleanup="${_CLEANUP}"
+        atexit ""
+        ${cleanup}
+    fi
+
+    exit $1
+}
+
+function pass
+{
+    [[ -n "$1" ]] && echo "$@"
+    _exit 0
+}
+
+function fail
+{
+    [[ -n "$1" ]] && echo "$@" >&2
+    _exit 1
+}
+
+function _run
+{
+    echo "$@"
+    "$@"
+    return $?
+}
+
+function expect_pass
+{
+    _run "$@"
+    local ret=$?
+
+    if [[ "${ret}" != "0" ]]; then
+        fail "Command failed unexpectedly"
+    fi
+
+    return 0
+}
+
+function expect_fail
+{
+    _run "$@"
+    local ret=$?
+
+    if [[ "${ret}" == "0" ]]; then
+        fail "Command succeeded unexpectedly"
+    fi
+
+    return 0
+}
+
+function expect_equal
+{
+    if [[ "$1" != "$2" ]]; then
+        fail "Expected $2, got $1"
+    fi
+
+    return 0
+}

--- a/tests/parse.py
+++ b/tests/parse.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+from __future__ import print_function
+
+import json
+import os
+import sys
+
+def parse(minor, field):
+    with open("/proc/datto-info") as f:
+        j = json.load(f)
+
+    for d in j["devices"]:
+        # Look for the object with the minor we want.
+        if d["minor"] != int(minor):
+            continue
+
+        if field in d:
+            print(d[field])
+            return 0
+
+        # Special case: Error field is not printed if there is none.
+        if field == "error":
+            print("0")
+            return 0
+
+    # Minor of field doesn't exist.
+    return 1
+
+if __name__ == "__main__":
+    minor = sys.argv[1]
+    field = sys.argv[2]
+
+    sys.exit(parse(minor, field))

--- a/tests/scripts/dbdctl/destroy/destroy_active_incremental.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_active_incremental.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+declare -r SNAP_DEVICE="/dev/datto${MINOR}"
+
+echo "Testing destroying active incremental will succeed"
+
+expect_pass ${DBDCTL} setup-snapshot ${DEVICE} ${MOUNT}/${COW_FILE} ${MINOR}
+sleep 0.1
+expect_pass test -e "${SNAP_DEVICE}"
+
+expect_pass ${DBDCTL} transition-to-incremental ${MINOR}
+sleep 0.1
+
+expect_pass ${DBDCTL} destroy ${MINOR}
+sleep 0.1
+expect_fail test -e "${SNAP_DEVICE}"
+
+pass

--- a/tests/scripts/dbdctl/destroy/destroy_active_snapshot.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_active_snapshot.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+declare -r SNAP_DEVICE="/dev/datto${MINOR}"
+
+echo "Testing destroying active snapshot will succeed"
+
+expect_pass ${DBDCTL} setup-snapshot ${DEVICE} ${MOUNT}/${COW_FILE} ${MINOR}
+sleep 0.1
+expect_pass test -e "${SNAP_DEVICE}"
+
+expect_pass ${DBDCTL} destroy ${MINOR}
+sleep 0.1
+expect_fail test -e "${SNAP_DEVICE}"
+
+pass

--- a/tests/scripts/dbdctl/destroy/destroy_dormant_incremental.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_dormant_incremental.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+declare -r SNAP_DEVICE="/dev/datto${MINOR}"
+
+cleanup() {
+    if ! is_mounted ${DEVICE}; then
+        expect_pass mount ${DEVICE} ${MOUNT}
+    fi
+
+    rm -r ${MOUNT}/${COW_FILE}
+}
+atexit cleanup
+
+echo "Testing destroying dormant incremental will succeed"
+
+expect_pass ${DBDCTL} setup-snapshot ${DEVICE} ${MOUNT}/${COW_FILE} ${MINOR}
+sleep 0.1
+expect_pass test -e "${SNAP_DEVICE}"
+
+expect_pass ${DBDCTL} transition-to-incremental ${MINOR}
+sleep 0.1
+
+expect_pass umount ${DEVICE}
+sleep 0.1
+
+expect_pass ${DBDCTL} destroy ${MINOR}
+sleep 0.1
+expect_fail test -e "${SNAP_DEVICE}"
+
+pass

--- a/tests/scripts/dbdctl/destroy/destroy_dormant_snapshot.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_dormant_snapshot.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+declare -r SNAP_DEVICE="/dev/datto${MINOR}"
+
+cleanup() {
+    if ! is_mounted ${DEVICE}; then
+        expect_pass mount ${DEVICE} ${MOUNT}
+    fi
+
+    rm -r ${MOUNT}/${COW_FILE}
+}
+atexit cleanup
+
+echo "Testing destroying dormant snapshot will succeed"
+
+expect_pass ${DBDCTL} setup-snapshot ${DEVICE} ${MOUNT}/${COW_FILE} ${MINOR}
+sleep 0.1
+expect_pass test -e "${SNAP_DEVICE}"
+
+expect_pass umount ${DEVICE}
+sleep 0.1
+
+expect_pass ${DBDCTL} destroy ${MINOR}
+sleep 0.1
+expect_fail test -e "${SNAP_DEVICE}"
+
+pass

--- a/tests/scripts/dbdctl/destroy/destroy_non_existing.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_non_existing.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+echo "Testing destroying non-existing snapshot will fail"
+
+expect_fail ${DBDCTL} destroy ${MINOR}
+
+pass

--- a/tests/scripts/dbdctl/destroy/destroy_unverified_incremental.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_unverified_incremental.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+declare -r SNAP_DEVICE="/dev/datto${MINOR}"
+
+cleanup() {
+    if ! is_mounted ${DEVICE}; then
+        expect_pass mount ${DEVICE} ${MOUNT}
+    fi
+}
+atexit cleanup
+
+echo "Testing destroying unverified snapshot will succeed"
+
+expect_pass umount ${MOUNT}
+sleep 0.1
+
+expect_pass ${DBDCTL} reload-incremental ${DEVICE} /${COW_FILE} ${MINOR}
+sleep 0.1
+
+expect_pass ${DBDCTL} destroy ${MINOR}
+
+pass

--- a/tests/scripts/dbdctl/destroy/destroy_unverified_snapshot.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_unverified_snapshot.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+declare -r SNAP_DEVICE="/dev/datto${MINOR}"
+
+cleanup() {
+    if ! is_mounted ${DEVICE}; then
+        expect_pass mount ${DEVICE} ${MOUNT}
+    fi
+}
+atexit cleanup
+
+echo "Testing destroying unverified snapshot will succeed"
+
+expect_pass umount ${MOUNT}
+sleep 0.1
+
+expect_pass ${DBDCTL} reload-snapshot ${DEVICE} /${COW_FILE} ${MINOR}
+sleep 0.1
+
+expect_pass ${DBDCTL} destroy ${MINOR}
+
+pass

--- a/tests/scripts/dbdctl/setup-snapshot/setup_invalid.sh
+++ b/tests/scripts/dbdctl/setup-snapshot/setup_invalid.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+echo "Testing snapshotting with an invalid parameters will fail"
+
+# Invalid block device
+expect_fail ${DBDCTL} setup-snasphot ${MOUNT} ${MOUNT}/${COW_FILE} ${MINOR}
+
+# Invalid cow file
+expect_fail ${DBDCTL} setup-snapshot ${DEVICE} ${MOUNT} ${MINOR}
+expect_fail ${DBDCTL} setup-snapshot ${DEVICE} /${COW_FILE} ${MINOR}
+
+# Invalid minor
+expect_fail ${DBDCTL} setup-snapshot ${DEVICE} ${MOUNT}/${COW_FILE} 99
+
+pass

--- a/tests/scripts/dbdctl/setup-snapshot/setup_readonly.sh
+++ b/tests/scripts/dbdctl/setup-snapshot/setup_readonly.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+cleanup() {
+    expect_pass mount -o remount,rw ${DEVICE} ${MOUNT}
+}
+atexit cleanup
+
+echo "Testing snapshotting a read-only device will fail"
+
+expect_pass is_mounted ${DEVICE}
+expect_pass mount -o remount,ro ${DEVICE} ${MOUNT}
+expect_fail ${DBDCTL} setup-snapshot ${DEVICE} ${MOUNT}/${COW_FILE} ${MINOR}
+
+pass

--- a/tests/scripts/dbdctl/setup-snapshot/setup_snapshot.sh
+++ b/tests/scripts/dbdctl/setup-snapshot/setup_snapshot.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+echo "Testing snapshotting a device will succeed"
+
+expect_pass ${DBDCTL} setup-snapshot ${DEVICE} ${MOUNT}/${COW_FILE} ${MINOR}
+
+error=$(parse ${MINOR} "error")
+expect_equal "${error}" "0"
+
+state=$(parse ${MINOR} "state")
+expect_equal "${state}" "3"
+
+cow=$(parse ${MINOR} "cow_file")
+expect_equal "${cow}" "/${COW_FILE}"
+
+bdev=$(parse ${MINOR} "block_device")
+expect_equal "${bdev}" "${DEVICE}"
+
+expect_pass ${DBDCTL} destroy ${MINOR}
+
+pass

--- a/tests/scripts/dbdctl/setup-snapshot/setup_twice.sh
+++ b/tests/scripts/dbdctl/setup-snapshot/setup_twice.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+echo "Testing snapshotting a device a second time will fail"
+
+expect_pass ${DBDCTL} setup-snapshot ${DEVICE} ${MOUNT}/${COW_FILE} 1
+sleep 0.1
+
+expect_fail ${DBDCTL} setup-snapshot ${DEVICE} ${MOUNT}/${COW_FILE} 2
+expect_pass ${DBDCTL} destroy 1
+
+pass

--- a/tests/scripts/dbdctl/setup-snapshot/setup_unmounted.sh
+++ b/tests/scripts/dbdctl/setup-snapshot/setup_unmounted.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+cleanup() {
+    if ! is_mounted ${DEVICE}; then
+        expect_pass mount ${DEVICE} ${MOUNT}
+    fi
+}
+atexit cleanup
+
+echo "Testing snapshotting an unmounted device will fail"
+
+expect_pass umount ${MOUNT}
+expect_fail ${DBDCTL} setup-snapshot ${DEVICE} ${MOUNT}/${COW_FILE} ${MINOR}
+
+pass

--- a/tests/scripts/dbdctl/transition-to-incremental/transition_cow_full.sh
+++ b/tests/scripts/dbdctl/transition-to-incremental/transition_cow_full.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+declare -r fallocate=50
+
+cleanup() {
+    expect_pass rm -f ${MOUNT}/zero
+    is_tracked ${MINOR} && expect_pass ${DBDCTL} destroy ${MINOR}
+}
+atexit cleanup
+
+echo "Testing transition to incremental will fail if it fills the cow file"
+
+for i in {1..5}; do
+    expect_pass ${DBDCTL} setup-snapshot -f ${fallocate} ${DEVICE} "${MOUNT}/${COW_FILE}" ${MINOR}
+
+    expect_pass dd if=/dev/zero of=${MOUNT}/zero bs=1M count=$((fallocate + 10))
+
+    # Possible errors doing this:
+    # * EINVAL: The file system already performed the sync
+    # * EFBIG: The module performed the sync
+    # We want the later to happen. However, the module sets the error to -27 in
+    # both cases, so the only way to check is the state it leaves the snapshot in.
+
+    expect_fail ${DBDCTL} transition-to-incremental ${MINOR}
+
+    error=$(parse ${MINOR} "error")
+    expect_equal "${error}" "-27"
+
+    state=$(parse ${MINOR} "state")
+    if [[ "${state}" != "2" ]]; then
+        cleanup
+        continue
+    fi
+
+    pass
+done
+
+fail

--- a/tests/scripts/functional/modify_origin.sh
+++ b/tests/scripts/functional/modify_origin.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2017 Datto, Inc.
+#
+# This file is part of dattobd.
+#
+# This file is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This file is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+
+source ${TEST_DIR}/include/common.sh
+source ${TEST_DIR}/include/libtest.sh
+
+init_env
+
+declare -r DATA_1="The quick brown fox"
+declare -r DATA_2="jumps over the lazy dog"
+declare -r FILE="file"
+declare -r SNAP_MOUNT="/mnt"
+declare -r SNAP_DEVICE="/dev/datto${MINOR}"
+
+echo "Testing snapshot does not change with original device"
+
+expect_pass eval "echo '${DATA_1}' > '${MOUNT}/${FILE}'"
+sync
+md5_orig=$(md5 "${MOUNT}/${FILE}")
+
+expect_pass ${DBDCTL} setup-snapshot ${DEVICE} "${MOUNT}/${COW_FILE}" ${MINOR}
+sleep 0.1
+
+expect_pass eval "echo '${DATA_2}' > '${MOUNT}/${FILE}'"
+sync
+
+expect_pass mount -o ro ${SNAP_DEVICE} ${SNAP_MOUNT}
+sleep 0.1
+
+expect_pass test -e "${SNAP_MOUNT}/${FILE}"
+md5_snap=$(md5 "${SNAP_MOUNT}/${FILE}")
+expect_equal ${md5_orig} ${md5_snap}
+
+expect_pass umount ${SNAP_MOUNT}
+sleep 0.1
+
+expect_pass ${DBDCTL} destroy ${MINOR}
+sleep 0.1
+
+expect_pass rm ${MOUNT}/${FILE}
+sync
+
+pass


### PR DESCRIPTION
Simple framework along with some tests to validate functionality.

Requires Python 2.7 for parsing the JSON proc file.