### PR TITLE
Lowercase module parameters

### DIFF
--- a/tests/dbdtest.sh
+++ b/tests/dbdtest.sh
@@ -79,7 +79,7 @@ setup_default_device || {
     exit 1
 }
 
-insert_module DEBUG=1 || exit 1
+insert_module debug=1 || exit 1
 
 ts=($(find_tests "${TEST_DIR}/scripts"))
 


### PR DESCRIPTION
* Change module parameters to lowercase
* Prefix module parameters with `dattobd`
* Use named parameters to expose nicer names to users