### PR TITLE
Enable shared library build by default and add library subpackage to spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ library-static:
 
 library: library-shared library-static
 
-application: library-static
+application-static: library-static
 	$(MAKE) -C app
 
-application-shared: library-shared
+application: library-shared
 	$(MAKE) -C app shared
 
-utils: library-static
+utils: library-shared
 	$(MAKE) -C utils
 
 clean:

--- a/app/Makefile
+++ b/app/Makefile
@@ -2,13 +2,13 @@ BINARY_NAME = dbdctl
 INSTALLDIR = $(PREFIX)/bin
 SOURCES = dbdctl.c
 
-.PHONY: static shared install-static install clean
-
-static:
-	$(CC) $(CCFLAGS) -o $(BINARY_NAME) $(SOURCES) $(BASE_DIR)/lib/libdattobd.a
+.PHONY: shared static install-static install clean
 
 shared:
 	$(CC) $(CCFLAGS) -o $(BINARY_NAME) -L $(BASE_DIR)/lib $(SOURCES) -ldattobd
+
+static:
+	$(CC) $(CCFLAGS) -o $(BINARY_NAME) $(SOURCES) $(BASE_DIR)/lib/libdattobd.a
 
 install-static: static
 	mkdir -p $(INSTALLDIR)

--- a/dist/libdattobd.pc.in
+++ b/dist/libdattobd.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=${prefix}
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libdattobd
+Description: Library for kernel module for taking block-level snapshots of Linux block devices
+Version: @PACKAGE_VERSION@
+
+Libs: -L${libdir} -ldattobd
+Cflags: -I${includedir}

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,7 +1,7 @@
-TARGET_LIB = libdattobd.so.0
-SONAME = libdattobd.so
-SHARED_CCFLAGS = -fPIC -lc -shared -Wl,-soname,$(SONAME)
-LIBDIR = $(PREFIX)/lib
+LIBNAME = libdattobd.so
+SOVER = 1
+SHARED_CCFLAGS = -fPIC -lc -shared -Wl,-soname,$(LIBNAME).$(SOVER)
+LIBDIR = $(PREFIX)/lib64
 
 SOURCES = libdattobd.c
 
@@ -10,16 +10,16 @@ SOURCES = libdattobd.c
 all: shared static
 
 shared:
-	$(CC) $(CCFLAGS) $(SHARED_CCFLAGS) $(SOURCES) -o $(TARGET_LIB)
-	ln -sf $(TARGET_LIB) $(SONAME)
+	$(CC) $(CCFLAGS) $(SHARED_CCFLAGS) $(SOURCES) -o $(LIBNAME).$(SOVER)
+	ln -sf $(LIBNAME).$(SOVER) $(LIBNAME)
 
 static:
 	$(CC) $(CCFLAGS) -c $(SOURCES)
 	ar rcs libdattobd.a libdattobd.o
 
 install: shared
-	install $(TARGET_LIB) $(LIBDIR)
-	ln -sf $(LIBDIR)/$(TARGET_LIB) $(LIBDIR)/$(SONAME)
+	install $(LIBNAME).$(SOVER) $(LIBDIR)
+	install $(LIBNAME) $(LIBDIR)
 	ldconfig
 
 clean:

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -3,12 +3,19 @@ INSTALLDIR = $(PREFIX)/bin
 SOURCES = update-img.c
 CCFLAGS = -D_XOPEN_SOURCE=500
 
-.PHONY: all install clean
+.PHONY: shared static install-static install clean
 
-all:
+shared:
+	$(CC) $(CCFLAGS) -o $(BINARY_NAME) -L $(BASE_DIR)/lib $(SOURCES) -ldattobd
+
+static:
 	$(CC) $(CCFLAGS) -o $(BINARY_NAME) $(SOURCES) $(BASE_DIR)/lib/libdattobd.a
 
-install: all
+install-static: static
+	mkdir -p $(INSTALLDIR)
+	install $(BINARY_NAME) $(INSTALLDIR)
+
+install: shared
 	mkdir -p $(INSTALLDIR)
 	install $(BINARY_NAME) $(INSTALLDIR)
 


### PR DESCRIPTION
This PR adjusts the build for dattobd so that shared library build is preferred and installed.

To accomplish this change, I've done the following:
* Fixed the shared library build for libdattobd and bumped the soname to reflect ABI breakage
* Fixed all component Makefiles to prefer shared library build
* Switched the main Makefile to prefer shared libraries, given the same install instructions
* Added pkgconfig file for libdattobd for applications to use to discover and link against the library
* Added library subpackages to the spec file

Fixes #98 