### PR TITLE
Compatibility with CentOS 7.4

### DIFF
--- a/src/configure-tests/feature-tests/enum_req_op.c
+++ b/src/configure-tests/feature-tests/enum_req_op.c
@@ -1,0 +1,16 @@
+/*
+    Copyright (C) 2017 Datto Inc.
+
+    This file is part of dattobd.
+
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License version 2 as published
+    by the Free Software Foundation.
+*/
+
+#include "../../includes.h"
+
+static inline void dummy(void){
+	enum req_op n = 0;
+	(void)n;
+}

--- a/src/configure-tests/feature-tests/uuid_h.c
+++ b/src/configure-tests/feature-tests/uuid_h.c
@@ -1,0 +1,16 @@
+/*
+    Copyright (C) 2017 Datto Inc.
+
+    This file is part of dattobd.
+
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License version 2 as published
+    by the Free Software Foundation.
+*/
+
+#include "../../includes.h"
+#include <linux/uuid.h>
+
+static inline void dummy(void){
+	generate_random_uuid(NULL);
+}

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -32,6 +32,10 @@ MODULE_VERSION(DATTOBD_VERSION);
 
 /*********************************REDEFINED FUNCTIONS*******************************/
 
+#ifdef HAVE_UUID_H
+#include <linux/uuid.h>
+#endif
+
 #ifndef HAVE_BIO_LIST
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,30)
 struct bio_list {
@@ -214,6 +218,7 @@ static struct block_device *blkdev_get_by_path(const char *path, fmode_t mode, v
 #define REQ_DISCARD 0
 #endif
 
+#ifndef HAVE_ENUM_REQ_OP
 typedef enum req_op {
 	REQ_OP_READ,
 	REQ_OP_WRITE,
@@ -248,6 +253,10 @@ static inline void dattobd_set_bio_ops(struct bio *bio, req_op_t op, unsigned op
 
 	bio->bi_rw |= op_flags;
 }
+#else
+	typedef enum req_op req_op_t;
+	#define dattobd_set_bio_ops(bio, op, flags) bio_set_op_attrs(bio, op, flags)
+#endif
 
 	#define bio_is_discard(bio) ((bio)->bi_rw & REQ_DISCARD)
 	#define dattobd_submit_bio(bio) submit_bio(0, bio)

--- a/src/includes.h
+++ b/src/includes.h
@@ -14,6 +14,7 @@
 #include <linux/module.h>
 #include <linux/moduleparam.h>
 #include <linux/blkdev.h>
+#include <linux/genhd.h>
 #include <linux/kthread.h>
 #include <linux/miscdevice.h>
 #include <linux/proc_fs.h>


### PR DESCRIPTION
Add configure tests for `enum req_op` and `uuid.h` for changes backported in RHEL 7.4.

Fixes #105