### PR TITLE
Add support for running the feature tests against non-running kernel

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 obj-m := dattobd.o
 
-KERNELVERSION = $(shell uname -r)
+KERNELVERSION ?= $(shell uname -r)
 KDIR := /lib/modules/$(KERNELVERSION)/build
 PWD := $(shell pwd)
 EXTRA_CFLAGS := -g

--- a/src/configure-tests/feature-tests/Makefile
+++ b/src/configure-tests/feature-tests/Makefile
@@ -1,6 +1,7 @@
 obj-m := $(OBJ)
 
-KDIR := /lib/modules/$(shell uname -r)/build
+KERNELVERSION ?= $(shell uname -r)
+KDIR := /lib/modules/$(KERNELVERSION)/build
 PWD := $(shell pwd)
 EXTRA_CFLAGS := -g -Werror
 

--- a/src/genconfig.sh
+++ b/src/genconfig.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-SRC_DIR=`dirname "$0"`
+SRC_DIR=$(dirname "$0")
 OUTPUT_FILE=$SRC_DIR/kernel-config.h
 FEATURE_TEST_DIR="$SRC_DIR/configure-tests/feature-tests"
 FEATURE_TEST_FILES="$FEATURE_TEST_DIR/*.c"
 SYMBOL_TESTS_FILE="$SRC_DIR/configure-tests/symbol-tests"
-KERNEL_VERSION=`uname -r`
+KERNEL_VERSION=$(uname -r)
 
 if [ ! -z "$1" ]; then
 	KERNEL_VERSION="$1"


### PR DESCRIPTION
In commit 1fd030c09f1e6ef2f92f428f7e0e609ad66bf18b, we changed the packaging such that the DKMS common scriptlet is used to build and install the module, which enabled DKMS to be correctly invoked in cases like building Linux distribution images or doing kernel upgrades.

However, the kernel feature test scripts used to configure the build of the kernel module continued to assume that the running kernel is always the correct target, which is not only wrong, but can lead to false failures for supported kernels as the build is configured for a kernel with a different feature set and ABI than what the target kernel is.

With this change, the feature test scripts are now guided to the correct kernel module build trees that was passed in by DKMS or by the user, which should fix the remaining major issues with having the module build properly on kernel or distribution upgrades.

This fixes #119.