### PR TITLE
Linux 4.14 compatibility

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,6 @@
 # Object files
 *.o
+*.o.d
 *.ko
 *.obj
 *.elf

--- a/src/configure-tests/feature-tests/bio_bi_bdev.c
+++ b/src/configure-tests/feature-tests/bio_bi_bdev.c
@@ -1,0 +1,16 @@
+/*
+    Copyright (C) 2017 Datto Inc.
+
+    This file is part of dattobd.
+
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License version 2 as published
+    by the Free Software Foundation.
+*/
+
+#include "../../includes.h"
+
+static inline void dummy(void){
+	struct bio bio;
+	bio.bi_bdev = NULL;
+}

--- a/src/configure-tests/feature-tests/kernel_write_ppos.c
+++ b/src/configure-tests/feature-tests/kernel_write_ppos.c
@@ -1,0 +1,19 @@
+/*
+    Copyright (C) 2017 Datto Inc.
+
+    This file is part of dattobd.
+
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License version 2 as published
+    by the Free Software Foundation.
+*/
+
+#include "../../includes.h"
+
+static inline void dummy(void){
+	struct file *f = NULL;
+	const void *buf = NULL;
+	loff_t *pos = NULL;
+
+	(void)kernel_write(f, buf, 0, pos);
+}


### PR DESCRIPTION
- Use new `kernel_{read,write}` if available
- Handle the removable of `bi_bdev` from `struct bio`
- Remove use of `raw_spin_unlock_wait`

Resolves #115