### PR TITLE
Use kvfree, remove COW_VMALLOC_UPPER

### DIFF
--- a/src/configure-tests/feature-tests/is_vmalloc_addr.c
+++ b/src/configure-tests/feature-tests/is_vmalloc_addr.c
@@ -1,0 +1,15 @@
+/*
+    Copyright (C) 2018 Datto Inc.
+
+    This file is part of dattobd.
+
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License version 2 as published
+    by the Free Software Foundation.
+*/
+
+#include "../../includes.h"
+
+static inline void dummy(void){
+	(void)is_vmalloc_addr(NULL);
+}

--- a/src/configure-tests/feature-tests/kvfree.c
+++ b/src/configure-tests/feature-tests/kvfree.c
@@ -1,0 +1,15 @@
+/*
+    Copyright (C) 2018 Datto Inc.
+
+    This file is part of dattobd.
+
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License version 2 as published
+    by the Free Software Foundation.
+*/
+
+#include "../../includes.h"
+
+static inline void dummy(void){
+	kvfree(NULL);
+}

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -55,7 +55,6 @@ struct reconfigure_params{
 #define COW_MAGIC ((uint32_t)4776)
 #define COW_CLEAN 0
 #define COW_INDEX_ONLY 1
-#define COW_VMALLOC_UPPER 2
 
 struct cow_header{
 	uint32_t magic; //COW header magic


### PR DESCRIPTION
`kvfree` will transparently handle freeing resources allocated using either `kmalloc` for `vmalloc`. Use this instead of manually tracking which type of allocation was made in the COW header. Remove now unneeded `COW_VMALLOC_UPPER` flag.