### PR TITLE
Add test for kernel_read introduced in 4.14

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,4 +1,5 @@
 # Object files
+.cache.mk
 *.o
 *.o.d
 *.ko

--- a/src/configure-tests/feature-tests/kernel_read_ppos.c
+++ b/src/configure-tests/feature-tests/kernel_read_ppos.c
@@ -1,0 +1,19 @@
+/*
+    Copyright (C) 2018 Datto Inc.
+
+    This file is part of dattobd.
+
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License version 2 as published
+    by the Free Software Foundation.
+*/
+
+#include "../../includes.h"
+
+static inline void dummy(void){
+	struct file *f = NULL;
+	void *buf = NULL;
+	loff_t *pos = NULL;
+
+	(void)kernel_read(f, buf, 0, pos);
+}

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -573,7 +573,7 @@ error:
 #endif
 
 static inline ssize_t dattobd_kernel_read(struct file *filp, void *buf, size_t count, loff_t *pos){
-#ifndef HAVE_KERNEL_WRITE_PPOS
+#ifndef HAVE_KERNEL_READ_PPOS
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
 	mm_segment_t old_fs;
 	ssize_t ret;


### PR DESCRIPTION
openSUSE 15 backported the `kernel_write` from 4.14, but not the corresponding `kernel_read` function. Add test for `kernel_read` to force openSUSE to use the old read implementation.

Resolves: #139 