### PR TITLE
Add make deb/rpm targets to build the packages locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Module.symvers
 # Leftover files
 *~
 tests/results
+
+# Project directories
+pkgbuild/

--- a/BUILDING-PACKAGE.md
+++ b/BUILDING-PACKAGE.md
@@ -1,0 +1,19 @@
+# Building the package
+
+This package is built using [debbuild](https://github.com/ascherer/debbuild) for Debian targets.
+
+The Makefile included in this project helps you to do builds, but you need
+to have debbuild installed first.
+
+You can install debbuild from the deb published on [the GitHub project releases](https://github.com/ascherer/debbuild/releases).
+
+Once installed, `make deb` will let you build a Debian package.
+
+For building RPMs, you just need `rpmbuild`. For example, on Fedora:
+
+```bash
+$ sudo dnf install rpm-build
+
+```
+
+Once installed, `make rpm` will let you build an RPM package.

--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -102,6 +102,10 @@
 
 %global devname %{libprefix}-%{devsuffix}
 
+# For local build stuff, disabled by default
+%bcond_with devmode
+
+
 Name:            dattobd
 Version:         0.10.5
 Release:         1%{?dist}
@@ -122,9 +126,14 @@ License:         GPLv2
 %endif
 
 URL:             https://github.com/datto/dattobd
-Source0:         https://github.com/datto/dattobd/archive/v%{version}/%{name}-%{version}.tar.gz
+%if ! %{with devmode}
+Source0:         %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
+%else
+Source0:         %{name}.tar.gz
+%endif
 
 BuildRequires:   rsync
+
 # Some targets (like EL5) expect a buildroot definition
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
@@ -253,7 +262,11 @@ automatically build and install for each kernel.
 
 
 %prep
+%if ! %{with devmode}
 %setup -q
+%else
+%setup -q -n %{name}
+%endif
 
 
 %build


### PR DESCRIPTION
We recently received an issue that dattobd packages were not available for Zesty. While it makes sense that we only maintain LTS releases in our package repo, it also makes sense that people should be able to build for whatever release they like. Therefore we would like to add a "make pkg" target to the dattobd Makefile.