### PR TITLE
Fix NULL dereference handling REQ_OP_WRITE_ZEROES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ modules.order
 Module.symvers
 *.cmd
 .tmp_versions/
+*.o.ur-safe
 
 # Leftover files
 *~


### PR DESCRIPTION
Attempting to iterate over a `REQ_OP_WRITE_ZEROES` bio would result in a NULL pointer dereference. This is used as a discard/unmap operation, but we want to track it.

On Ubuntu 18.04, this would be
```
BUG: unable to handle kernel NULL pointer dereference at 0000000000000008
IP: tracing_mrf+0x144/0x6f0 [dattobd]
```
```
(gdb) list *(tracing_mrf+0x144)
0x3014 is in tracing_mrf (/root/dattobd/src/dattobd.c:2372).
2367    static int bio_needs_cow(struct bio *bio, struct inode *inode){
2368        bio_iter_t iter;
2369        bio_iter_bvec_t bvec;
2370    
2371        //check the inode of each page return true if it does not match our cow file
2372        bio_for_each_segment(bvec, bio, iter){
2373            if(page_get_inode(bio_iter_page(bio, iter)) != inode) return 1;
2374        }
2375    
2376        return 0;
```

Tested on:
- Ubuntu 18.04 (4.15.0-23-generic) (has `REQ_OP_WRITE_ZEROES`)
- Fedora 26 (4.16.11-100.fc26.x86_64) (has `REQ_OP_WRITE_ZEROES`)
- openSUSE 42 (4.4.138-59-default) (backported `REQ_OP_WRITE_ZEROES`)
- CentOS 7 (3.10.0-862.6.3.el7.x86_64) (does not have `REQ_OP_WRITE_ZEROES`)