### PR TITLE
Handle bioset_init for Linux 4.18

### DIFF
--- a/src/configure-tests/feature-tests/bioset_init.c
+++ b/src/configure-tests/feature-tests/bioset_init.c
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2017 Datto Inc.
+    Copyright (C) 2018 Datto Inc.
 
     This file is part of dattobd.
 
@@ -11,6 +11,7 @@
 #include "../../includes.h"
 
 static inline void dummy(void){
-	int flags = BIOSET_NEED_BVECS;
-	(void)flags;
+	struct bio_set bs;
+
+	(void)bioset_init(&bs, 0, 0, 0);
 }


### PR DESCRIPTION
Linux 4.18 replaced `bioset_{create,free}` with `bioset_{init,exit}`.

Fix `bioset_need_bvecs_flag` test, which was using `bioset_create`.