### PR TITLE
init: Make root device read-only during mount

### DIFF
--- a/dist/initramfs/dracut/install
+++ b/dist/initramfs/dracut/install
@@ -3,6 +3,7 @@
 inst_hook pre-mount 01 "$moddir/dattobd.sh"
 inst_dir /etc/datto/dla/mnt
 inst /sbin/blkid
+inst /sbin/blockdev
 inst /usr/bin/udevadm
 inst /usr/bin/dbdctl
 inst_simple /var/lib/datto/dla/reload /sbin/datto_reload

--- a/dist/initramfs/dracut/module-setup.sh
+++ b/dist/initramfs/dracut/module-setup.sh
@@ -18,6 +18,7 @@ install() {
     inst_hook pre-mount 01 "$moddir/dattobd.sh"
     inst_dir /etc/datto/dla/mnt
     inst /sbin/blkid
+    inst /sbin/blockdev
     inst /usr/bin/udevadm
     inst /usr/bin/dbdctl
     inst_simple /var/lib/datto/dla/reload /sbin/datto_reload

--- a/dist/initramfs/initramfs-tools/hooks/dattobd
+++ b/dist/initramfs/initramfs-tools/hooks/dattobd
@@ -18,6 +18,7 @@ esac
 
 mkdir -p ${DESTDIR}/etc/datto/dla/mnt
 copy_exec /sbin/blkid
+copy_exec /sbin/blockdev
 copy_exec /usr/bin/dbdctl
 copy_exec /var/lib/datto/dla/reload /sbin/datto_reload
 

--- a/dist/initramfs/initramfs-tools/scripts/dattobd
+++ b/dist/initramfs/initramfs-tools/scripts/dattobd
@@ -4,56 +4,59 @@ PREREQ=""
 
 prereqs()
 {
-	echo "$PREREQ"
+    echo "$PREREQ"
 }
 
 case $1 in
-	prereqs)
-		prereqs
-		exit 0
-		;;
+    prereqs)
+        prereqs
+        exit 0
+        ;;
 esac
 
 modprobe dattobd
 
-rbd=""
+rbd="${ROOT#block:}"
+if [ -n "$rbd" ]; then
+    case "$rbd" in
+        LABEL=*)
+            rbd="$(echo $rbd | sed 's,/,\\x2f,g')"
+            rbd="/dev/disk/by-label/${rbd#LABEL=}"
+            ;;
+        UUID=*)
+            rbd="/dev/disk/by-uuid/${ROOT#UUID=}"
+            ;;
+        PARTLABEL=*)
+            rbd="/dev/disk/by-partlabel/${rbd#PARTLABEL=}"
+            ;;
+        PARTUUID=*)
+            rbd="/dev/disk/by-partuuid/${rbd#PARTUUID=}"
+            ;;
+    esac
 
-echo "ROOT = $ROOT" > /dev/kmsg
+    echo "dattobd: root block device = $rbd" > /dev/kmsg
 
-if test "${ROOT#*/dev/disk/by-uuid/}" != $ROOT; then
-	rbd=${ROOT#/dev/disk/by-uuid/}
-	echo "matched /dev/disk/by-uuid/ rbd1=$rbd " > /dev/kmsg
-	rbd=$(blkid -t UUID=$rbd -o device)
-	echo "matched /dev/disk/by-uuid/ rbd2=$rbd " > /dev/kmsg
-elif test "${ROOT#*/dev/mapper/}" != $ROOT; then
-	rbd=$ROOT
-	echo "matched /dev/mapper/ rbd=$rbd " > /dev/kmsg
+    # Device might not be ready
+    if [ ! -b "$rbd" ]; then
+        udevadm settle
+    fi
 
-# the new ubuntu 16.04 way is ROOT=UUID=xyz
-elif test "${ROOT#*UUID=}" != $ROOT; then
-	rbd=${ROOT#UUID=}
-	echo "matched UUID= rbd1=$rbd " > /dev/kmsg
-	rbd=$(blkid -t UUID=$rbd -o device)
-	echo "matched UUID= rbd2=$rbd " > /dev/kmsg
-else
-	echo "Unable to parse ROOT volume $ROOT, can not persist this volume through reboot." > /dev/kmsg
-fi
+    # Kernel cmdline might not specify rootfstype
+    [ -z "$ROOTFSTYPE" ] && ROOTFSTYPE=$(blkid -s TYPE -o value $rbd)
 
-echo "RBD = $rbd" > /dev/kmsg
+    echo "dattobd: mounting $rbd as $ROOTFSTYPE" > /dev/kmsg
+    blockdev --setro $rbd
+    mount -t $ROOTFSTYPE -o ro $rbd /etc/datto/dla/mnt > /dev/kmsg
+    udevadm settle
 
-if [ -b "$rbd" ]
-then
-	if [ -z "$ROOTFSTYPE" ]; then
-		ROOTFSTYPE=$(blkid -s TYPE $rbd)
-		ROOTFSTYPE=${ROOTFSTYPE#*TYPE\=\"}
-		ROOTFSTYPE=${ROOTFSTYPE%\"*}
-	fi
-	mount -t $ROOTFSTYPE -o ro $rbd /etc/datto/dla/mnt > /dev/kmsg
-	sleep 1
-	if [ -x /sbin/datto_reload ]; then
-		/sbin/datto_reload > /dev/kmsg
-	fi
-	umount -f /etc/datto/dla/mnt > /dev/kmsg
+    if [ -x /sbin/datto_reload ]; then
+        /sbin/datto_reload
+    else
+        echo "dattobd: error: cannot reload tracking data: missing /sbin/datto_reload" > /dev/kmsg
+    fi
+
+    umount -f /etc/datto/dla/mnt > /dev/kmsg
+    blockdev --setrw $rbd
 fi
 
 exit 0

--- a/dist/initramfs/initrd/boot-dattobd.sh
+++ b/dist/initramfs/initrd/boot-dattobd.sh
@@ -6,16 +6,18 @@
 #%depends: lvm2
 #%modules: dattobd
 #%programs: /usr/bin/dbdctl
-#%programs: /usr/sbin/blkid
 #%programs: /sbin/lsmod
 #%programs: /sbin/modprobe
-#%programs: /usr/bin/mount
-#%programs: /usr/bin/umount
 #%programs: /sbin/blkid
+#%programs: /usr/sbin/blkid
+#%programs: /sbin/blockdev
+#%programs: /usr/sbin/blockdev
 #%programs: /bin/mount
+#%programs: /usr/bin/mount
 #%programs: /bin/umount
-#%programs: /usr/bin/readlink
-#%programs: /bin/readlink
+#%programs: /usr/bin/umount
+#%programs: /bin/udevadm
+#%programs: /usr/bin/udevadm
 
 echo "datto dlad load_modules" > /dev/kmsg
 # this is a function in linuxrc, modprobes dattobd for us.
@@ -23,63 +25,45 @@ load_modules
 
 /sbin/modprobe --allow-unsupported dattobd
 
-echo "datto dlad root = $root" > /dev/kmsg
+rbd="${root#block:}"
+if [ -n "$rbd" ]; then
+    case "$rbd" in
+        LABEL=*)
+            rbd="$(echo $rbd | sed 's,/,\\x2f,g')"
+            rbd="/dev/disk/by-label/${rbd#LABEL=}"
+            ;;
+        UUID=*)
+            rbd="/dev/disk/by-uuid/${rbd#UUID=}"
+            ;;
+        PARTLABEL=*)
+            rbd="/dev/disk/by-partlabel/${rbd#PARTLABEL=}"
+            ;;
+        PARTUUID=*)
+            rbd="/dev/disk/by-partuuid/${rbd#PARTUUID=}"
+            ;;
+    esac
 
-rbd=""
+    echo "dattobd: root block device = $rbd" > /dev/kmsg
 
-if [ -n "$root"  ]; then
-	rbd=""
-	# check for UUID first
-	echo "datto dlad checking UUID" > /dev/kmsg
-	if [[ "$root" == "UUID="* ]]; then
-	  echo "datto dlad UUID match" > /dev/kmsg
-	  rbd=/dev/disk/by-uuid/${root:5}
-	  echo "datto dlad found uuid: $rbd" > /dev/kmsg
-        elif test "${root#*/dev/disk/by-uuid/}" != $root; then
-        	echo "datto dlad disk by-uuid match" > /dev/kmsg
-		rbd=${root#block:/dev/disk/by-uuid/}
-        	echo "datto dlad disk by-uuid strip $rbd" > /dev/kmsg
-		rbd=$(blkid -t UUID=$rbd -o device)
-	  	echo "datto dlad found disk by-uuid: $rbd" > /dev/kmsg
-	elif test "${root#*/dev/mapper/}" != $root; then
-        	echo "datto dlad dev mapper match" > /dev/kmsg
-		rbd=${root#block:}
-	  	echo "datto dlad found dev mapper: $rbd" > /dev/kmsg
-	elif test "${root#*/dev/disk/by-id/}" != $root; then
-        	echo "datto dlad disk by id match" > /dev/kmsg
-	        echo "rbd= (/usr/bin/readlink -f $root)" > /dev/kmsg
-	        rbd=$(/usr/bin/readlink -f $root)
-	  	echo "datto dlad found disk by id: $rbd" > /dev/kmsg
-	else
-	  	echo "datto dlad found nothing" > /dev/kmsg
-	fi
+    # Device might not be ready
+    if [ ! -b "$rbd" ]; then
+        udevadm settle
+    fi
 
-	echo "datto dlad RBD = $rbd" > /dev/kmsg
+    # Kernel cmdline might not specify rootfstype
+    [ -z "$rootfstype" ] && rootfstype=$(blkid -s TYPE -o value $rbd)
 
-	fstype=$rootfstype
-	if [ -b "$rbd" ]; then
-		if [ -z "$fstype" ]; then
-		echo "fstype not set, scanning from blkid" > /dev/kmsg
-			fstype=$(blkid -s TYPE $rbd)
-			fstype=${fstype#*TYPE\=\"}
-			fstype=${fstype%\"*}
-		fi
-		echo "datto dlad mounting $rbd as $fstype" > /dev/kmsg
-		mount -t $fstype -o ro "$rbd" /etc/datto/dla/mnt > /dev/kmsg
-		sleep 1
-		echo "datto dlad checking for datto_reload" > /dev/kmsg
-		if [ -x /sbin/datto_reload ]; then
-			echo "datto dlad found datto_reload..." > /dev/kmsg
-			/sbin/datto_reload > /dev/kmsg
-		else
-			echo "datto dlad did not find datto_reload..." > /dev/kmsg
-		fi
-		echo "datto dlad Unmounting $rbd from /etc/datto/dla/mnt" > /dev/kmsg
-		umount -f /etc/datto/dla/mnt > /dev/kmsg
-	else
-		echo "datto dlad rbd: $rbd is not a block device" > /dev/kmsg
-	fi
-else
-	echo "datto dlad root is empty" > /dev/kmsg
+    echo "dattobd: mounting $rbd as $rootfstype" > /dev/kmsg
+    blockdev --setro $rbd
+    mount -t $fstype -o ro "$rbd" /etc/datto/dla/mnt > /dev/kmsg
+    udevadm settle
+
+    if [ -x /sbin/datto_reload ]; then
+        /sbin/datto_reload
+    else
+        echo "dattobd: error: cannot reload tracking data: missing /sbin/datto_reload" > /dev/kmsg
+    fi
+
+    umount -f /etc/datto/dla/mnt > /dev/kmsg
+    blockdev --setrw $rbd
 fi
-


### PR DESCRIPTION
File systems such as ext4 may mount a volume read-write if the log is dirty, even is `-o ro` is specified. Per the mount man page, set the block device read-only before mount and read-write after unmount.

Rewrite the initramfs-tools and initrd scripts to be consistent with the dracut version.

Resolves #151