### PR TITLE
Track the number of changed blocks

### DIFF
--- a/doc/STRUCTURE.md
+++ b/doc/STRUCTURE.md
@@ -47,11 +47,15 @@ The header and index are always present as part of the file. The datastore is al
 
 The COW file header comprises the first 4096 bytes of the file, split up as follows:
 
-* 0x0000 - 0x0004 : File signature
-* 0x0005 - 0x0008 : Flags
-* 0x0009 - 0x000F : Location of file pointer
-* 0x0010 - 0x0018 : Amount of disk space allocated for snapshot mode COW file.
-* 0x0019 - 0xFFFF : Empty
+* 0x0000 - 0x0003 : File signature
+* 0x0004 - 0x0007 : Flags
+* 0x0008 - 0x000F : Location of file pointer
+* 0x0010 - 0x0017 : Amount of disk space allocated for snapshot mode COW file
+* 0x0018 - 0x001F : Sequence ID of snapshot
+* 0x0020 - 0x002F : UUID for snapshot series
+* 0x0030 - 0x0037 : Version of the header format
+* 0x0038 - 0x003F : Number of changed blocks since snapshot
+* 0x0040 - 0xFFFF : Empty
 
 Most of the header is left empty, for future usage and alignment concerns.
 

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -57,6 +57,9 @@ struct reconfigure_params{
 #define COW_INDEX_ONLY 1
 #define COW_VMALLOC_UPPER 2
 
+#define COW_VERSION_0 0
+#define COW_VERSION_CHANGED_BLOCKS 1
+
 struct cow_header{
 	uint32_t magic; //COW header magic
 	uint32_t flags; //COW file flags
@@ -64,6 +67,8 @@ struct cow_header{
 	uint64_t fsize; //file size
 	uint64_t seqid; //seqential id of snapshot (starts at 1)
 	uint8_t uuid[COW_UUID_SIZE]; //uuid for this series of snapshots
+	uint64_t version; //version of cow file format
+	uint64_t nr_changed_blocks; //number of changed blocks since last snapshot
 };
 
 struct dattobd_info{
@@ -76,6 +81,8 @@ struct dattobd_info{
 	char uuid[COW_UUID_SIZE];
 	char cow[PATH_MAX];
 	char bdev[PATH_MAX];
+	unsigned long long version;
+	unsigned long long nr_changed_blocks;
 };
 
 #define IOCTL_SETUP_SNAP _IOW(DATTO_IOCTL_MAGIC, 1, struct setup_params) //in: see above


### PR DESCRIPTION
Add a field that can be used to calculate how much data has changed since the last snapshot. This information is exposed in both the proc file and through the info ioctl.

For compatibility, a version is also added to the header. Devices with unversioned headers will continue to work, without tracking changes. The driver will automatically upgrade to the newer format on the next
snapshot.

Resolves #148