### PR TITLE
Write the COW header after allocating the file

### DIFF
--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -2032,9 +2032,6 @@ static int cow_init(char *path, uint64_t elements, unsigned long sect_size, unsi
 	if(uuid) memcpy(cm->uuid, uuid, COW_UUID_SIZE);
 	else generate_random_uuid(cm->uuid);
 
-	ret = __cow_write_header_dirty(cm);
-	if(ret) goto error;
-
 	LOG_DEBUG("allocating cow manager array (%lu sections)", cm->total_sects);
 	cm->sects = kzalloc((cm->total_sects) * sizeof(struct cow_section), GFP_KERNEL | __GFP_NOWARN);
 	if(!cm->sects){
@@ -2050,6 +2047,9 @@ static int cow_init(char *path, uint64_t elements, unsigned long sect_size, unsi
 
 	LOG_DEBUG("allocating cow file (%llu bytes)", (unsigned long long)file_max);
 	ret = file_allocate(cm->filp, 0, file_max);
+	if(ret) goto error;
+
+	ret = __cow_write_header_dirty(cm);
 	if(ret) goto error;
 
 	*cm_out = cm;


### PR DESCRIPTION
The header was being overwritten when `fallocate` was not supported, causing backups to fail on the new agent. I would be interested to know how it was working on newer kernels.

This would also fix the flags in the case of `vzalloc` being used.

Tested on:
- CentOS 6 (2.6.32-754.6.3.el6.x86_64)
- CentOS 7 (3.10.0-957.1.3.el7.x86_64)
- Fedora 28 (4.18.18-200.fc28.x86_64)

Tested:
- COW file header is populated for ext2, ext3, ext4, XFS, FAT32, and NTFS volumes

Setup:
```
declare -a fs=(ext2 ext3 ext4 xfs fat ntfs)

for i in ${!fs[@]}; do
    img=${fs[$i]}

    fallocate -l 1G $img

    case ${fs[$i]} in
    ext*)
        mkfs.${fs[$i]} -F $img
        ;;
    xfs)
        mkfs.xfs $img
        ;;
    ntfs)
        mkfs.ntfs -F -f $img
        ;;
    fat)
        mkfs.vfat -F32 $img
        ;;
    esac

    sync

    losetup /dev/loop$i $img
    mkdir -p /mnt/${fs[$i]}
    mount /dev/loop$i /mnt/${fs[$i]}
done
```