### PR TITLE
Use SPDX short identifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
 export CC = gcc
 export RM = rm -f
 CFLAGS ?= -Wall

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
 BINARY_NAME = dbdctl
 INSTALLDIR = $(PREFIX)/bin
 SOURCES = dbdctl.c

--- a/app/dbdctl.c
+++ b/app/dbdctl.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include <stdio.h>
 #include <string.h>

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 LIBNAME = libdattobd.so
 SOVER = 1
 SHARED_CCFLAGS = -fPIC -lc -shared -Wl,-soname,$(LIBNAME).$(SOVER)

--- a/lib/libdattobd.c
+++ b/lib/libdattobd.c
@@ -1,13 +1,8 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of the License, or
-    or (at your option) any later version.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include <unistd.h>
 #include <fcntl.h>

--- a/lib/libdattobd.h
+++ b/lib/libdattobd.h
@@ -1,13 +1,8 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of the License, or
-    or (at your option) any later version.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #ifndef LIBDATTOBD_H_
 #define LIBDATTOBD_H_

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
 obj-m := dattobd.o
 
 KERNELVERSION ?= $(shell uname -r)

--- a/src/configure-tests/feature-tests/Makefile
+++ b/src/configure-tests/feature-tests/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
 obj-m := $(OBJ)
 
 KERNELVERSION ?= $(shell uname -r)

--- a/src/configure-tests/feature-tests/__dentry_path.c
+++ b/src/configure-tests/feature-tests/__dentry_path.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bd_super.c
+++ b/src/configure-tests/feature-tests/bd_super.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bdev_stack_limits.c
+++ b/src/configure-tests/feature-tests/bdev_stack_limits.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bdops_open_inode.c
+++ b/src/configure-tests/feature-tests/bdops_open_inode.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bdops_open_int.c
+++ b/src/configure-tests/feature-tests/bdops_open_int.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bio_bi_bdev.c
+++ b/src/configure-tests/feature-tests/bio_bi_bdev.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2017 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2017 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bio_bi_pool.c
+++ b/src/configure-tests/feature-tests/bio_bi_pool.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bio_bi_remaining.c
+++ b/src/configure-tests/feature-tests/bio_bi_remaining.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bio_endio_1.c
+++ b/src/configure-tests/feature-tests/bio_endio_1.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bio_endio_int.c
+++ b/src/configure-tests/feature-tests/bio_endio_int.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bio_list.c
+++ b/src/configure-tests/feature-tests/bio_list.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bioset_create_3.c
+++ b/src/configure-tests/feature-tests/bioset_create_3.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bioset_init.c
+++ b/src/configure-tests/feature-tests/bioset_init.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2018 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2018 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bioset_need_bvecs_flag.c
+++ b/src/configure-tests/feature-tests/bioset_need_bvecs_flag.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2017 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2017 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/blk_set_default_limits.c
+++ b/src/configure-tests/feature-tests/blk_set_default_limits.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/blk_set_stacking_limits.c
+++ b/src/configure-tests/feature-tests/blk_set_stacking_limits.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/blk_status_t.c
+++ b/src/configure-tests/feature-tests/blk_status_t.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/blkdev_get_by_path.c
+++ b/src/configure-tests/feature-tests/blkdev_get_by_path.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/blkdev_put_1.c
+++ b/src/configure-tests/feature-tests/blkdev_put_1.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bvec_iter.c
+++ b/src/configure-tests/feature-tests/bvec_iter.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/bvec_merge_data.c
+++ b/src/configure-tests/feature-tests/bvec_merge_data.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/d_unlinked.c
+++ b/src/configure-tests/feature-tests/d_unlinked.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/dentry_path_raw.c
+++ b/src/configure-tests/feature-tests/dentry_path_raw.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/enum_req_op.c
+++ b/src/configure-tests/feature-tests/enum_req_op.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2017 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2017 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/enum_req_opf.c
+++ b/src/configure-tests/feature-tests/enum_req_opf.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2017 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2017 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/file_inode.c
+++ b/src/configure-tests/feature-tests/file_inode.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/fmode_t.c
+++ b/src/configure-tests/feature-tests/fmode_t.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/fops_fallocate.c
+++ b/src/configure-tests/feature-tests/fops_fallocate.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/genhd_fl_no_part_scan.c
+++ b/src/configure-tests/feature-tests/genhd_fl_no_part_scan.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/inode_lock.c
+++ b/src/configure-tests/feature-tests/inode_lock.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/iops_fallocate.c
+++ b/src/configure-tests/feature-tests/iops_fallocate.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/kern_path.c
+++ b/src/configure-tests/feature-tests/kern_path.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/kernel_read_ppos.c
+++ b/src/configure-tests/feature-tests/kernel_read_ppos.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2018 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2018 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/kernel_write_ppos.c
+++ b/src/configure-tests/feature-tests/kernel_write_ppos.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2017 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2017 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/make_request_fn_int.c
+++ b/src/configure-tests/feature-tests/make_request_fn_int.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/make_request_fn_void.c
+++ b/src/configure-tests/feature-tests/make_request_fn_void.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/merge_bvec_fn.c
+++ b/src/configure-tests/feature-tests/merge_bvec_fn.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/mnt_want_write.c
+++ b/src/configure-tests/feature-tests/mnt_want_write.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/noop_llseek.c
+++ b/src/configure-tests/feature-tests/noop_llseek.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/notify_change_2.c
+++ b/src/configure-tests/feature-tests/notify_change_2.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/part_nr_sects_read.c
+++ b/src/configure-tests/feature-tests/part_nr_sects_read.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/path_put.c
+++ b/src/configure-tests/feature-tests/path_put.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/proc_create.c
+++ b/src/configure-tests/feature-tests/proc_create.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/sb_start_write.c
+++ b/src/configure-tests/feature-tests/sb_start_write.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/struct_path.c
+++ b/src/configure-tests/feature-tests/struct_path.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/submit_bio_1.c
+++ b/src/configure-tests/feature-tests/submit_bio_1.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/submit_bio_wait.c
+++ b/src/configure-tests/feature-tests/submit_bio_wait.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/sys_oldumount.c
+++ b/src/configure-tests/feature-tests/sys_oldumount.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/task_struct_task_works_cb_head.c
+++ b/src/configure-tests/feature-tests/task_struct_task_works_cb_head.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/task_struct_task_works_hlist.c
+++ b/src/configure-tests/feature-tests/task_struct_task_works_hlist.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/thaw_bdev_int.c
+++ b/src/configure-tests/feature-tests/thaw_bdev_int.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/user_path_at.c
+++ b/src/configure-tests/feature-tests/user_path_at.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/uuid_h.c
+++ b/src/configure-tests/feature-tests/uuid_h.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2017 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2017 Datto Inc.
+ */
 
 #include "includes.h"
 #include <linux/uuid.h>

--- a/src/configure-tests/feature-tests/vfs_fallocate.c
+++ b/src/configure-tests/feature-tests/vfs_fallocate.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/vfs_unlink_2.c
+++ b/src/configure-tests/feature-tests/vfs_unlink_2.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/configure-tests/feature-tests/vzalloc.c
+++ b/src/configure-tests/feature-tests/vzalloc.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #include "includes.h"
 #include "kernel-config.h"

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -1,13 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only WITH Linux-syscall-note */
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 2.1 of the License, or
-    or (at your option) any later version.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #ifndef DATTOBD_H_
 #define DATTOBD_H_

--- a/src/genconfig.sh
+++ b/src/genconfig.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 SRC_DIR=$(dirname "$0")
 OUTPUT_FILE=$SRC_DIR/kernel-config.h

--- a/src/includes.h
+++ b/src/includes.h
@@ -1,12 +1,8 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #ifndef DATTOBD_INCLUDES_H_
 #define DATTOBD_INCLUDES_H_

--- a/tests/dbdtest.sh
+++ b/tests/dbdtest.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 export TEST_DIR="$(cd ${0%/*} && pwd)"

--- a/tests/include/common.sh
+++ b/tests/include/common.sh
@@ -1,16 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 # Initialize environment variables

--- a/tests/include/libtest.sh
+++ b/tests/include/libtest.sh
@@ -1,16 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 function atexit

--- a/tests/parse.py
+++ b/tests/parse.py
@@ -1,18 +1,8 @@
 #!/usr/bin/env python
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 from __future__ import print_function

--- a/tests/scripts/dbdctl/destroy/destroy_active_incremental.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_active_incremental.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/destroy/destroy_active_snapshot.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_active_snapshot.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/destroy/destroy_dormant_incremental.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_dormant_incremental.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/destroy/destroy_dormant_snapshot.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_dormant_snapshot.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/destroy/destroy_non_existing.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_non_existing.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/destroy/destroy_unverified_incremental.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_unverified_incremental.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/destroy/destroy_unverified_snapshot.sh
+++ b/tests/scripts/dbdctl/destroy/destroy_unverified_snapshot.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/setup-snapshot/setup_invalid.sh
+++ b/tests/scripts/dbdctl/setup-snapshot/setup_invalid.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/setup-snapshot/setup_readonly.sh
+++ b/tests/scripts/dbdctl/setup-snapshot/setup_readonly.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/setup-snapshot/setup_snapshot.sh
+++ b/tests/scripts/dbdctl/setup-snapshot/setup_snapshot.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/setup-snapshot/setup_twice.sh
+++ b/tests/scripts/dbdctl/setup-snapshot/setup_twice.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/setup-snapshot/setup_unmounted.sh
+++ b/tests/scripts/dbdctl/setup-snapshot/setup_unmounted.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/dbdctl/transition-to-incremental/transition_cow_full.sh
+++ b/tests/scripts/dbdctl/transition-to-incremental/transition_cow_full.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/tests/scripts/functional/modify_origin.sh
+++ b/tests/scripts/functional/modify_origin.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-only
 
 #
 # Copyright (C) 2017 Datto, Inc.
-#
-# This file is part of dattobd.
-#
-# This file is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public
-# License v2 as published by the Free Software Foundation.
-#
-# This file is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
 #
 
 source ${TEST_DIR}/include/common.sh

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
 BINARY_NAME = update-img
 INSTALLDIR = $(PREFIX)/bin
 SOURCES = update-img.c

--- a/utils/update-img.c
+++ b/utils/update-img.c
@@ -1,12 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
 /*
-    Copyright (C) 2015 Datto Inc.
-
-    This file is part of dattobd.
-
-    This program is free software; you can redistribute it and/or modify it
-    under the terms of the GNU General Public License version 2 as published
-    by the Free Software Foundation.
-*/
+ * Copyright (C) 2015 Datto Inc.
+ */
 
 #define _FILE_OFFSET_BITS 64
 #define __USE_LARGEFILE64


### PR DESCRIPTION
Add SPDX (https://spdx.org/) IDs to quickly and easily identify licenses for files.