### PR TITLE
Fix deadlock warning when opening snapshot device

### DIFF
--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -800,7 +800,7 @@ struct snap_device{
 	unsigned long sd_state; //current state of the snapshot
 	unsigned long sd_falloc_size; //space allocated to the cow file (in megabytes)
 	unsigned long sd_cache_size; //maximum cache size (in bytes)
-	unsigned int sd_refs; //number of users who have this device open
+	atomic_t sd_refs; //number of users who have this device open
 	atomic_t sd_fail_code; //failure return code
 	sector_t sd_sect_off; //starting sector of base block device
 	sector_t sd_size; //size of device in sectors
@@ -3982,7 +3982,7 @@ static int __verify_minor(unsigned int minor, int mode){
 		}
 
 		//check that the device is not busy if we care
-		if(mode == 1 && snap_devices[minor]->sd_refs){
+		if(mode == 1 && atomic_read(&snap_devices[minor]->sd_refs)){
 			LOG_ERROR(-EBUSY, "device specified is busy");
 			return -EBUSY;
 		}
@@ -4856,9 +4856,7 @@ static int __tracer_add_ref(struct snap_device *dev, int ref_cnt){
 		goto error;
 	}
 
-	mutex_lock(&ioctl_mutex);
-	dev->sd_refs += ref_cnt;
-	mutex_unlock(&ioctl_mutex);
+	atomic_add(ref_cnt, &dev->sd_refs);
 
 error:
 	return ret;


### PR DESCRIPTION
lockdep produces a deadlock warning between the ioctl mutex and the bdev mutex. Convert `sd_refs` to atomic so we don't need to use the ioctl lock when opening the block device.

`refcount_t` was not used as it is not available in older kernels.

Resolves: #170