### PR TITLE
proc: Fix off-by-one accessing device on start

### DIFF
--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -4959,7 +4959,7 @@ static inline void *dattobd_proc_get_idx(loff_t pos){
 
 static void *dattobd_proc_start(struct seq_file *m, loff_t *pos){
 	if(*pos == 0) return SEQ_START_TOKEN;
-	return dattobd_proc_get_idx(*pos);
+	return dattobd_proc_get_idx(*pos - 1);
 }
 
 static void *dattobd_proc_next(struct seq_file *m, void *v, loff_t *pos){


### PR DESCRIPTION
If we start with position other than 0, we would be accessing the *next* device to print, and the procfs output would be wrong. This can be observed by printing the proc file using small reads, such as:
```
dd if=/proc/datto-info bs=32 status=none
```

Fix the off-by-one array access.

Resolves: #174