### PR TITLE
Use the head of compound pages

### DIFF
--- a/src/configure-tests/feature-tests/compound_head.c
+++ b/src/configure-tests/feature-tests/compound_head.c
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2019 Datto Inc.
+ */
+
+#include "includes.h"
+
+static inline void dummy(void){
+	struct page *p = NULL;
+
+	(void)compound_head(p);
+}

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -2380,13 +2380,14 @@ static void tp_put(struct tracing_params *tp){
 
 static inline struct inode *page_get_inode(struct page *pg){
 	if(!pg) return NULL;
-	if(!pg->mapping) return NULL;
-	if(PageAnon(pg)) return NULL;
-//#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,5,0)
-#ifdef TAIL_MAPPING
-	if (pg->mapping == TAIL_MAPPING) return NULL;
+
+	// page_mapping() was not exported until 4.8, use compound_head() instead
+#ifdef HAVE_COMPOUND_HEAD
+//#if LINUX_VERSION_CODE >= KERNEL_VERSION(2.6.22)
+	pg = compound_head(pg);
 #endif
-	if(!pg->mapping->host) return NULL;
+	if(PageAnon(pg)) return NULL;
+	if(!pg->mapping) return NULL;
 	return pg->mapping->host;
 }
 


### PR DESCRIPTION
In e3e6a3b76804d I had modified `page_get_inode()` to check for tail
mappings specifically. A problem that was encountered on Ubuntu was that
tail mappings might use a seemingly bogus poison offset of `0xffffffff`
instead of TAIL_MAPPING. Fix this by always operating on the compound
head instead of using a tail.

Tested on:
- CentOS 6 (2.6.32-754.14.2.el6.x86_64)
- CentOS 7 (3.10.0-957.12.2.el7.x86_64)
- Fedora 29 (5.0.17-200.fc29.x86_64)
- Ubuntu 16.04 (4.4.0-150-generic)
- Ubuntu 18.04 (4.15.0-50-generic)

Resolves: #184
See also: #40