### PR TITLE
Add IOCTL to get next free minor

### DIFF
--- a/lib/libdattobd.c
+++ b/lib/libdattobd.c
@@ -140,3 +140,17 @@ int dattobd_info(unsigned int minor, struct dattobd_info *info){
 	close(fd);
 	return ret;
 }
+
+int dattobd_get_free_minor(void){
+	int fd, ret, minor;
+
+	fd = open("/dev/datto-ctl", O_RDONLY);
+	if(fd < 0) return -1;
+
+	ret = ioctl(fd, IOCTL_GET_FREE, &minor);
+
+	close(fd);
+
+	if(!ret) return minor;
+	return ret;
+}

--- a/lib/libdattobd.h
+++ b/lib/libdattobd.h
@@ -29,6 +29,13 @@ int dattobd_reconfigure(unsigned int minor, unsigned long cache_size);
 
 int dattobd_info(unsigned int minor, struct dattobd_info *info);
 
+/**
+ * Get the first available minor.
+ *
+ * @returns non-negative number if minor is available, otherwise -1
+ */
+int dattobd_get_free_minor(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -88,5 +88,6 @@ struct dattobd_info{
 #define IOCTL_TRANSITION_SNAP _IOW(DATTO_IOCTL_MAGIC, 6, struct transition_snap_params) //in: see above
 #define IOCTL_RECONFIGURE _IOW(DATTO_IOCTL_MAGIC, 7, struct reconfigure_params) //in: see above
 #define IOCTL_DATTOBD_INFO _IOR(DATTO_IOCTL_MAGIC, 8, struct dattobd_info) //in: see above
+#define IOCTL_GET_FREE _IOR(DATTO_IOCTL_MAGIC, 9, int)
 
 #endif /* DATTOBD_H_ */

--- a/tests/dattobd.py
+++ b/tests/dattobd.py
@@ -36,6 +36,7 @@ int dattobd_transition_incremental(unsigned int minor);
 int dattobd_transition_snapshot(unsigned int minor, char *cow, unsigned long fallocated_space);
 int dattobd_reconfigure(unsigned int minor, unsigned long cache_size);
 int dattobd_info(unsigned int minor, struct dattobd_info *info);
+int dattobd_get_free_minor(void);
 """)
 
 lib = ffi.dlopen("../lib/libdattobd.so")
@@ -149,6 +150,12 @@ def info(minor):
         "version": di.version,
         "nr_changed_blocks": di.nr_changed_blocks,
     }
+
+def get_free_minor():
+    ret = lib.dattobd_get_free_minor()
+    if (ret < 0):
+        return -ffi.errno
+    return ret
 
 def version():
     with open("/sys/module/dattobd/version", "r") as v:

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -71,6 +71,15 @@ class TestSnapshot(DeviceTestCase):
         end_nr = info["nr_changed_blocks"]
         self.assertGreater(end_nr, start_nr)
 
+    def test_next_available_minor(self):
+        self.assertEqual(dattobd.get_free_minor(), 0)
+
+        # Explicitly use a minor of 0 for testing this function
+        self.assertEqual(dattobd.setup(0, self.device, self.cow_full_path), 0)
+        self.addCleanup(dattobd.destroy, 0)
+
+        self.assertEqual(dattobd.get_free_minor(), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The agent (any user, really) currently gets a free minor by parsing the proc file JSON and iterates through the existing devices. Push this complexity down into the driver, where it's a simple for-loop.