### PR TITLE
Multipage bio (kernel 5.1+) fix

### DIFF
--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -723,7 +723,7 @@ static inline void dattobd_bio_copy_dev(struct bio *dst, struct bio *src){
 #define BLOCK_TO_SECTOR(block) ((block) * SECTORS_PER_BLOCK)
 
 //maximum number of clones per traced bio
-#define MAX_CLONES_PER_BIO 5
+#define MAX_CLONES_PER_BIO 10
 
 //macros for compilation
 #define MAYBE_UNUSED(x) (void)(x)

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -2883,10 +2883,17 @@ static void __on_bio_read_complete(struct bio *bio, int err){
 		goto error;
 	}
 
+	/*
+	 * Reset the position in each bvec. Unnecessary with bvec iterators. Will cause multipage bvec capable kernels to
+	 * lock up.
+	 */
+#ifndef HAVE_BVEC_ITER
+//#if LINUX_VERSION_CODE < KERNEL_VERSION(3,14,0)
 	for(i = 0; i < bio->bi_vcnt; i++){
 		bio->bi_io_vec[i].bv_len = PAGE_SIZE;
 		bio->bi_io_vec[i].bv_offset = 0;
 	}
+#endif
 
 	/*
 	 * drop our reference to the tp (will queue the orig_bio if nobody else is using it)


### PR DESCRIPTION
Fixes #186 

This bumps the number of traced `bio_sects` so we can process larger bios, which was the observed problem with "error tracing bio for snapshot: -14". There was also a size reset which is not valid any more, and would cause the machine to lock on a cow file overrun.