### PR TITLE
Parallelize feature tests

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ INSTALL_MOD_DIR ?= extra
 EXTRA_CFLAGS := -g
 
 default:
-	if [ ! -f kernel-config.h ] || tail -1 kernel-config.h | grep -qv '#endif'; then ./genconfig.sh $(KERNELVERSION); fi;
+	if [ ! -f kernel-config.h ] || tail -1 kernel-config.h | grep -qv '#endif'; then ./genconfig.sh "$(KERNELVERSION)" "$(MFLAGS)"; fi;
 	$(MAKE) -C $(KDIR) M=$(PWD) modules
 
 clean:

--- a/src/configure-tests/feature-tests/Makefile
+++ b/src/configure-tests/feature-tests/Makefile
@@ -6,9 +6,17 @@ KERNELVERSION ?= $(shell uname -r)
 KDIR := /lib/modules/$(KERNELVERSION)/build
 PWD := $(shell pwd)
 EXTRA_CFLAGS := -g -Werror -I$(src)/../..
+BUILDDIR ?= $(PWD)/build/$(OBJ)
+BUILDDIR_MAKEFILE ?= $(PWD)/build/$(OBJ)/Makefile
 
-default:
-	$(MAKE) -C $(KDIR) M=$(PWD) modules
+default: $(BUILDDIR_MAKEFILE)
+	$(MAKE) -C $(KDIR) M=$(BUILDDIR) src=$(PWD) modules
+
+$(BUILDDIR):
+	mkdir -p "$@"
+
+$(BUILDDIR_MAKEFILE): $(BUILDDIR)
+	touch "$@"
 
 clean:
-	$(MAKE) -C $(KDIR) M=$(PWD) clean
+	$(MAKE) -C $(KDIR) M=$(BUILDDIR) src=$(PWD) clean


### PR DESCRIPTION
I made genconfig.sh aware of Makefile flags, specifically the `-j`/`--jobs` flag. I passed through `$MFLAGS` to it, so that it can parse out the `-j` value. Make seems to turn a `--jobs` flag into a `-j` flag when it spits out `$MFLAGS`, so the regex only searches for `-j`. Also sed was giving me a hard time about searching for hyphens.

Feature tests will now each build inside of their own directory in `src/configure-tests/feature-tests/build/{test name}.o/`. This allows these tests to be parallelized since the builds won't clobber each other.