### PR TITLE
dist: Add gcc and make dependencies to ensure package build works

### DIFF
--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -132,6 +132,8 @@ Source0:         %{url}/archive/v%{version}/%{name}-%{version}.tar.gz
 Source0:         %{name}.tar.gz
 %endif
 
+BuildRequires:   gcc
+BuildRequires:   make
 BuildRequires:   rsync
 
 # Some targets (like EL5) expect a buildroot definition
@@ -235,6 +237,9 @@ Requires(post):  dkms
 # be cautious and just require it across the EL releases.
 Requires:        perl
 %endif
+
+# Dependencies for actually building the kmod
+Requires:        make
 
 %if %{_vendor} != "debbuild"
 %if 0%{?rhel} >= 6 || 0%{?suse_version} >= 1210 || 0%{?fedora}


### PR DESCRIPTION
On recent Fedora releases, we are observing that tools like make
are not necessarily always installed on the system when
DKMS is installed. Since we need make for the Makefiles in dattobd,
we will now directly require it.

Moreover, we now specify gcc as build dependency because it is no
longer part of the minimal build environment in Fedora.