### PR TITLE
Fix an error message during kernel module installation

### DIFF
--- a/src/configure-tests/feature-tests/Makefile
+++ b/src/configure-tests/feature-tests/Makefile
@@ -18,5 +18,5 @@ $(BUILDDIR):
 $(BUILDDIR_MAKEFILE): $(BUILDDIR)
 	touch "$@"
 
-clean:
+clean: $(BUILDDIR)
 	$(MAKE) -C $(KDIR) M=$(BUILDDIR) src=$(PWD) clean


### PR DESCRIPTION
There was a message like 'find: .../build/configure-tests/feature-tests/build/ No such file or directory'
During the dkms build of the kernel module sources.
As it turned out, this doesn't affect feature tests build and execution.
The fix is to create missing directory if it doesn't exist on the first clean.

Resolves https://github.com/datto/dattobd/issues/216

@Conan-Kudo please review.