### PR TITLE
Impl for kernel 5.8 - handling with null mrf

### DIFF
--- a/src/configure-tests/feature-tests/blk_alloc_queue_1.c
+++ b/src/configure-tests/feature-tests/blk_alloc_queue_1.c
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2021 Datto Inc.
+ */
+
+#include "includes.h"
+
+static inline void dummy(void){
+    struct request_queue *rq = blk_alloc_queue(GFP_KERNEL);
+}

--- a/src/configure-tests/feature-tests/blk_alloc_queue_2.c
+++ b/src/configure-tests/feature-tests/blk_alloc_queue_2.c
@@ -7,5 +7,7 @@
 #include "includes.h"
 
 static inline void dummy(void){
-    struct request_queue *rq = blk_alloc_queue(GFP_KERNEL);
+    make_request_fn *fn;
+    struct request_queue *rq = blk_alloc_queue(fn, NUMA_NO_NODE);
+    (void)rq;
 }

--- a/src/configure-tests/feature-tests/blk_alloc_queue_rh_2.c
+++ b/src/configure-tests/feature-tests/blk_alloc_queue_rh_2.c
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2021 Datto Inc.
+ */
+
+#include "includes.h"
+
+static inline void dummy(void){
+    make_request_fn *fn;
+    struct request_queue *rq = blk_alloc_queue_rh(fn, NUMA_NO_NODE);
+    (void)rq;
+}

--- a/src/configure-tests/feature-tests/proc_ops.c
+++ b/src/configure-tests/feature-tests/proc_ops.c
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2021 Datto Inc.
+ */
+
+#include "includes.h"
+
+static inline void dummy(void){
+    struct proc_ops test;
+	proc_create("", 0, NULL, &test);
+}

--- a/src/dattobd.c
+++ b/src/dattobd.c
@@ -934,7 +934,8 @@ static const struct seq_operations dattobd_seq_proc_ops = {
 	.show = dattobd_proc_show,
 };
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0)
+#ifndef HAVE_PROC_OPS
+//#if LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0)
 static const struct file_operations dattobd_proc_fops = {
 	.owner = THIS_MODULE,
 	.open = dattobd_proc_open,
@@ -3633,7 +3634,8 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor, stru
 
 	//allocate request queue
 	LOG_DEBUG("allocating queue");
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)
+#ifdef HAVE_BLOCK_ALLOC_QUEUE_1
+//#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)
 	dev->sd_queue = blk_alloc_queue(GFP_KERNEL);
 #else
 	dev->sd_queue = blk_alloc_queue(snap_mrf, NUMA_NO_NODE);
@@ -3644,9 +3646,10 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor, stru
 		goto error;
 	}
 
+#ifdef HAVE_BLOCK_ALLOC_QUEUE_1
+//#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)	
 	//register request handler
 	LOG_DEBUG("setting up make request function");
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)	
 	blk_queue_make_request(dev->sd_queue, snap_mrf);
 #endif
 	//give our request queue the same properties as the base device's

--- a/src/includes.h
+++ b/src/includes.h
@@ -22,6 +22,5 @@
 #include <linux/vmalloc.h>
 #include <linux/random.h>
 #include <asm/div64.h>
-#include <linux/version.h>
 
 #endif


### PR DESCRIPTION
This builds on #229, providing feature tests instead of kernel version macros, as well as proper handling of null make_request_fn (MRF) pointers. This will probably change again soon when I make 5.9 changes, since MRFs were moved to sumbit_bio.

This is intended to be merged after the aforementioned MR. This should also handle RHEL 8.4 issues in #252 and #260.