### PR TITLE
If insmod/rmmod fails, I'd like to know why

### DIFF
--- a/tests/kmod.py
+++ b/tests/kmod.py
@@ -25,16 +25,12 @@ class Module(object):
 
         subprocess.check_call(
             cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
             timeout=self.timeout)
 
     def unload(self):
         cmd = ["rmmod", self.name]
         subprocess.check_call(
             cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
             timeout=self.timeout)
 
     def info(self):


### PR DESCRIPTION
Don't suppress output from these commands in the test scaffold