### PR TITLE
Non-resident COW files

### DIFF
--- a/src/bio_helper.h
+++ b/src/bio_helper.h
@@ -148,7 +148,7 @@ void dattobd_bio_op_clear_flag(struct bio *bio, unsigned int flag);
 
 struct inode *page_get_inode(struct page *pg);
 
-int bio_needs_cow(struct bio *bio, struct inode *inode);
+int bio_needs_cow(struct bio *bio, struct snap_device *dev);
 
 void bio_free_clone(struct bio *bio);
 

--- a/src/proc_seq_file.c
+++ b/src/proc_seq_file.c
@@ -91,6 +91,8 @@ static int dattobd_proc_show(struct seq_file *m, void *v)
                 seq_printf(m, "\t\t\t\"minor\": %u,\n", dev->sd_minor);
                 seq_printf(m, "\t\t\t\"cow_file\": \"%s\",\n",
                            dev->sd_cow_path);
+                seq_printf(m, "\t\t\t\"full_cow_path\": \"%s\",\n",
+                           dev->sd_cow_full_path);
                 seq_printf(m, "\t\t\t\"block_device\": \"%s\",\n",
                            dev->sd_bdev_path);
                 seq_printf(m, "\t\t\t\"max_cache\": %lu,\n",
@@ -133,7 +135,8 @@ static int dattobd_proc_show(struct seq_file *m, void *v)
                 if (error)
                         seq_printf(m, "\t\t\t\"error\": %d,\n", error);
 
-                seq_printf(m, "\t\t\t\"state\": %lu\n", dev->sd_state);
+                seq_printf(m, "\t\t\t\"state\": %lu,\n", dev->sd_state);
+                seq_printf(m, "\t\t\t\"resident\": %d\n", test_bit(SD_FLAG_COW_RESIDENT, &dev->sd_flags));
                 seq_printf(m, "\t\t}");
         }
 

--- a/src/snap_device.h
+++ b/src/snap_device.h
@@ -16,9 +16,13 @@
 #define ACTIVE 1
 #define UNVERIFIED 2
 
+// macros for defining the flags of a snap_device (bit offsets)
+#define SD_FLAG_COW_RESIDENT 0 // the cow file exists on the backing device
+
 struct snap_device {
         unsigned int sd_minor; // minor number of the snapshot
         unsigned long sd_state; // current state of the snapshot
+        unsigned long sd_flags; // flags
         unsigned long sd_falloc_size; // space allocated to the cow file (in
                 // megabytes)
         unsigned long sd_cache_size; // maximum cache size (in bytes)
@@ -31,7 +35,8 @@ struct snap_device {
         struct block_device *sd_base_dev; // device being snapshot
         char *sd_bdev_path; // base device file path
         struct cow_manager *sd_cow; // cow manager
-        char *sd_cow_path; // cow file path
+        char *sd_cow_path; // cow file path (for resident cow files)
+        char *sd_cow_full_path; // full cow file path (for non-resident cow files)
         struct inode *sd_cow_inode; // cow file inode
         make_request_fn
                 *sd_orig_mrf; // block device's original make request function

--- a/src/system_call_hooking.c
+++ b/src/system_call_hooking.c
@@ -90,16 +90,11 @@ int __handle_bdev_mount_nowrite(const struct vfsmount *mnt,
                     dev->sd_base_dev != mnt->mnt_sb->s_bdev)
                         continue;
 
-                // if we are unmounting the vfsmount we are using go to dormant
-                // state
-                if (mnt == dattobd_get_mnt(dev->sd_cow->filp)) {
-                        LOG_DEBUG("block device umount detected for device %d",
-                                  i);
-                        auto_transition_dormant(i);
+                LOG_DEBUG("block device umount detected for device %d", i);
+                auto_transition_dormant(i);
 
-                        ret = 0;
-                        goto out;
-                }
+                ret = 0;
+                goto out;
         }
         i = 0;
         ret = -ENODEV;


### PR DESCRIPTION
Cow files can now exist off of the disk it is cow-ing. This comes with a
few limitations:
1. You cannot unmount a device with an active cow file on it. You would
   have to destroy or unmount the device being snapshotted by that cow
   file. DattoBD will hold the file handle to the cow file and will
   prevent the unmount.
2. Don't create loops with the snapshotted devices. If device A's cow
   file exists on device B, and device B's cow file is on device A, then
   you wouldn't be able to unmount either device or shutdown the
   machine. You'd have to destroy either snapshot to be able to unmount.

This commit also adds some fields to the /proc/datto-info device. The
`resident` field is a 0/1 false/true value that answers the question of
whether the cow file is on the device it is tracking. The
`full_cow_path` field represents the full path to the cow device, rather
than `cow_file`'s relative-to-mountpoint path. You are encouraged to use
the new `full_cow_path` field; `cow_file` will be kept, but deprecated,
for backwards compatibility.

Both of these limitations intend to be addressed in the future.