### PR TITLE
Added MODULE_LICENSE to all feature tests.

### DIFF
--- a/src/configure-tests/feature-tests/__dentry_path.c
+++ b/src/configure-tests/feature-tests/__dentry_path.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	char *c = NULL;
 	struct dentry d;

--- a/src/configure-tests/feature-tests/bd_super.c
+++ b/src/configure-tests/feature-tests/bd_super.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct block_device bd;
 	bd.bd_super = 0;

--- a/src/configure-tests/feature-tests/bdev_stack_limits.c
+++ b/src/configure-tests/feature-tests/bdev_stack_limits.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct queue_limits *t;
 	struct block_device *bdev;

--- a/src/configure-tests/feature-tests/bdops_open_inode.c
+++ b/src/configure-tests/feature-tests/bdops_open_inode.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static int snap_open(struct inode *inode, struct file *filp){
 	return 0;
 }

--- a/src/configure-tests/feature-tests/bdops_open_int.c
+++ b/src/configure-tests/feature-tests/bdops_open_int.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static int snap_open(struct block_device *bdev, fmode_t mode){
 	return 0;
 }

--- a/src/configure-tests/feature-tests/bio_bi_bdev.c
+++ b/src/configure-tests/feature-tests/bio_bi_bdev.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct bio bio;
 	bio.bi_bdev = NULL;

--- a/src/configure-tests/feature-tests/bio_bi_pool.c
+++ b/src/configure-tests/feature-tests/bio_bi_pool.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct bio bio;
 	bio.bi_pool = NULL;

--- a/src/configure-tests/feature-tests/bio_bi_remaining.c
+++ b/src/configure-tests/feature-tests/bio_bi_remaining.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct bio b;
 	atomic_inc(&b.bi_remaining);

--- a/src/configure-tests/feature-tests/bio_endio_1.c
+++ b/src/configure-tests/feature-tests/bio_endio_1.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	bio_endio(NULL);
 }

--- a/src/configure-tests/feature-tests/bio_endio_int.c
+++ b/src/configure-tests/feature-tests/bio_endio_int.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static int dummy_endio(struct bio *bio, unsigned int bytes, int err){
 	return 0;
 }

--- a/src/configure-tests/feature-tests/bio_list.c
+++ b/src/configure-tests/feature-tests/bio_list.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct bio_list bl;
 	bio_list_init(&bl);

--- a/src/configure-tests/feature-tests/bioset_create_3.c
+++ b/src/configure-tests/feature-tests/bioset_create_3.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct bio_set *bs;
 	int bio_pool_size;

--- a/src/configure-tests/feature-tests/bioset_init.c
+++ b/src/configure-tests/feature-tests/bioset_init.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct bio_set bs;
 

--- a/src/configure-tests/feature-tests/bioset_need_bvecs_flag.c
+++ b/src/configure-tests/feature-tests/bioset_need_bvecs_flag.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	int flags = BIOSET_NEED_BVECS;
 	(void)flags;

--- a/src/configure-tests/feature-tests/blk_alloc_queue_1.c
+++ b/src/configure-tests/feature-tests/blk_alloc_queue_1.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
     struct request_queue *rq = blk_alloc_queue(GFP_KERNEL);
 }

--- a/src/configure-tests/feature-tests/blk_alloc_queue_2.c
+++ b/src/configure-tests/feature-tests/blk_alloc_queue_2.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
     make_request_fn *fn;
     struct request_queue *rq = blk_alloc_queue(fn, NUMA_NO_NODE);

--- a/src/configure-tests/feature-tests/blk_alloc_queue_rh_2.c
+++ b/src/configure-tests/feature-tests/blk_alloc_queue_rh_2.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 
     make_request_fn *fn;

--- a/src/configure-tests/feature-tests/blk_set_default_limits.c
+++ b/src/configure-tests/feature-tests/blk_set_default_limits.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct queue_limits *l = NULL;
 	blk_set_default_limits(l);

--- a/src/configure-tests/feature-tests/blk_set_stacking_limits.c
+++ b/src/configure-tests/feature-tests/blk_set_stacking_limits.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct queue_limits *l = NULL;
 	blk_set_stacking_limits(l);

--- a/src/configure-tests/feature-tests/blk_status_t.c
+++ b/src/configure-tests/feature-tests/blk_status_t.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	blk_status_t b = BLK_STS_OK;
 	(void)b;

--- a/src/configure-tests/feature-tests/blkdev_get_by_path.c
+++ b/src/configure-tests/feature-tests/blkdev_get_by_path.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct block_device *bd = blkdev_get_by_path("path", FMODE_READ, NULL);
 	if(bd) bd = NULL;

--- a/src/configure-tests/feature-tests/blkdev_put_1.c
+++ b/src/configure-tests/feature-tests/blkdev_put_1.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct block_device bd;
 	blkdev_put(&bd);

--- a/src/configure-tests/feature-tests/bvec_iter.c
+++ b/src/configure-tests/feature-tests/bvec_iter.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct bvec_iter iter;
 	if(iter.bi_sector) iter.bi_sector = 0;

--- a/src/configure-tests/feature-tests/bvec_merge_data.c
+++ b/src/configure-tests/feature-tests/bvec_merge_data.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct bvec_merge_data bmd;
 	bmd.bi_bdev = NULL;

--- a/src/configure-tests/feature-tests/compound_head.c
+++ b/src/configure-tests/feature-tests/compound_head.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct page *p = NULL;
 

--- a/src/configure-tests/feature-tests/d_unlinked.c
+++ b/src/configure-tests/feature-tests/d_unlinked.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct dentry d;
 	d_unlinked(&d);

--- a/src/configure-tests/feature-tests/dentry_path_raw.c
+++ b/src/configure-tests/feature-tests/dentry_path_raw.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	char *c = NULL;
 	struct dentry d;

--- a/src/configure-tests/feature-tests/enum_req_op.c
+++ b/src/configure-tests/feature-tests/enum_req_op.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	enum req_op n = 0;
 	(void)n;

--- a/src/configure-tests/feature-tests/enum_req_opf.c
+++ b/src/configure-tests/feature-tests/enum_req_opf.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	enum req_opf n = 0;
 	(void)n;

--- a/src/configure-tests/feature-tests/file_inode.c
+++ b/src/configure-tests/feature-tests/file_inode.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct file *f;
 	file_inode(f);

--- a/src/configure-tests/feature-tests/fmode_t.c
+++ b/src/configure-tests/feature-tests/fmode_t.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	fmode_t f;
 	f = 0;

--- a/src/configure-tests/feature-tests/fops_fallocate.c
+++ b/src/configure-tests/feature-tests/fops_fallocate.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct file f = { .f_version = 0 };
 	f.f_op->fallocate(&f, 0, 0, 0);

--- a/src/configure-tests/feature-tests/genhd_fl_no_part_scan.c
+++ b/src/configure-tests/feature-tests/genhd_fl_no_part_scan.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct gendisk gd;
 	gd.flags = GENHD_FL_NO_PART_SCAN;

--- a/src/configure-tests/feature-tests/inode_lock.c
+++ b/src/configure-tests/feature-tests/inode_lock.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct inode i;
 	inode_lock(&i);

--- a/src/configure-tests/feature-tests/iops_fallocate.c
+++ b/src/configure-tests/feature-tests/iops_fallocate.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct inode i = { .i_sb = NULL };
 	i.i_op->fallocate(&i, 0, 0, 0);

--- a/src/configure-tests/feature-tests/kern_path.c
+++ b/src/configure-tests/feature-tests/kern_path.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct path p;
 	kern_path("", 0, &p);

--- a/src/configure-tests/feature-tests/kernel_read_ppos.c
+++ b/src/configure-tests/feature-tests/kernel_read_ppos.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct file *f = NULL;
 	void *buf = NULL;

--- a/src/configure-tests/feature-tests/kernel_write_ppos.c
+++ b/src/configure-tests/feature-tests/kernel_write_ppos.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct file *f = NULL;
 	const void *buf = NULL;

--- a/src/configure-tests/feature-tests/make_request_fn_int.c
+++ b/src/configure-tests/feature-tests/make_request_fn_int.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static int dummy_mrf(struct request_queue *q, struct bio *bio){
 	return 0;
 }

--- a/src/configure-tests/feature-tests/make_request_fn_void.c
+++ b/src/configure-tests/feature-tests/make_request_fn_void.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static void dummy_mrf(struct request_queue *q, struct bio *bio){
 	return;
 }

--- a/src/configure-tests/feature-tests/merge_bvec_fn.c
+++ b/src/configure-tests/feature-tests/merge_bvec_fn.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static int dummy_merge_bvec(struct request_queue *q, struct bvec_merge_data *bvm, struct bio_vec *bvec){
 	return 0;
 }

--- a/src/configure-tests/feature-tests/mnt_want_write.c
+++ b/src/configure-tests/feature-tests/mnt_want_write.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct vfsmount *mnt;
 	mnt_want_write(mnt);

--- a/src/configure-tests/feature-tests/noop_llseek.c
+++ b/src/configure-tests/feature-tests/noop_llseek.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct file f;
 	noop_llseek(&f, 0, 0);

--- a/src/configure-tests/feature-tests/notify_change_2.c
+++ b/src/configure-tests/feature-tests/notify_change_2.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct dentry d;
 	struct iattr a;

--- a/src/configure-tests/feature-tests/part_nr_sects_read.c
+++ b/src/configure-tests/feature-tests/part_nr_sects_read.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct hd_struct hd;
 	part_nr_sects_read(&hd);

--- a/src/configure-tests/feature-tests/path_put.c
+++ b/src/configure-tests/feature-tests/path_put.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct path p;
 	path_put(&p);

--- a/src/configure-tests/feature-tests/proc_create.c
+++ b/src/configure-tests/feature-tests/proc_create.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct proc_dir_entry *ent = proc_create("file", 0, NULL, NULL);
 	(void)ent;

--- a/src/configure-tests/feature-tests/proc_ops.c
+++ b/src/configure-tests/feature-tests/proc_ops.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
     struct proc_ops test;
 	proc_create("", 0, NULL, &test);

--- a/src/configure-tests/feature-tests/sb_start_write.c
+++ b/src/configure-tests/feature-tests/sb_start_write.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct inode i;
 	sb_start_write(i.i_sb);

--- a/src/configure-tests/feature-tests/struct_path.c
+++ b/src/configure-tests/feature-tests/struct_path.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct path p;
 	p.mnt = NULL;

--- a/src/configure-tests/feature-tests/submit_bio_1.c
+++ b/src/configure-tests/feature-tests/submit_bio_1.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	submit_bio(NULL);
 }

--- a/src/configure-tests/feature-tests/submit_bio_wait.c
+++ b/src/configure-tests/feature-tests/submit_bio_wait.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct bio bio;
 	submit_bio_wait(0, &bio);

--- a/src/configure-tests/feature-tests/sys_oldumount.c
+++ b/src/configure-tests/feature-tests/sys_oldumount.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline int dummy(void){
 	return __NR_umount;
 }

--- a/src/configure-tests/feature-tests/task_struct_task_works_cb_head.c
+++ b/src/configure-tests/feature-tests/task_struct_task_works_cb_head.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct callback_head *ch = current->task_works;
 	ch->func(ch);

--- a/src/configure-tests/feature-tests/task_struct_task_works_hlist.c
+++ b/src/configure-tests/feature-tests/task_struct_task_works_hlist.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct hlist_head *hl = current->task_works;
 	hlist_empty(hl);

--- a/src/configure-tests/feature-tests/thaw_bdev_int.c
+++ b/src/configure-tests/feature-tests/thaw_bdev_int.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct block_device bd;
 	struct super_block sb;

--- a/src/configure-tests/feature-tests/uapi_mount_h.c
+++ b/src/configure-tests/feature-tests/uapi_mount_h.c
@@ -7,6 +7,8 @@
 #include "includes.h"
 #include <uapi/linux/mount.h>
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	int f = MS_RDONLY;
 	(void)f;

--- a/src/configure-tests/feature-tests/user_path_at.c
+++ b/src/configure-tests/feature-tests/user_path_at.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	user_path_at(0, "dummy", 0, NULL);
 }

--- a/src/configure-tests/feature-tests/uuid_h.c
+++ b/src/configure-tests/feature-tests/uuid_h.c
@@ -7,6 +7,8 @@
 #include "includes.h"
 #include <linux/uuid.h>
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	generate_random_uuid(NULL);
 }

--- a/src/configure-tests/feature-tests/vfs_fallocate.c
+++ b/src/configure-tests/feature-tests/vfs_fallocate.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct file *f;
 	vfs_fallocate(f, 0, 0, 0);

--- a/src/configure-tests/feature-tests/vfs_unlink_2.c
+++ b/src/configure-tests/feature-tests/vfs_unlink_2.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	struct inode i;
 	struct dentry d;

--- a/src/configure-tests/feature-tests/vzalloc.c
+++ b/src/configure-tests/feature-tests/vzalloc.c
@@ -6,6 +6,8 @@
 
 #include "includes.h"
 
+MODULE_LICENSE("GPL");
+
 static inline void dummy(void){
 	vzalloc(0);
 }


### PR DESCRIPTION
Configure tests on 5.11 onwards would incorrectly enumerate features trying to build dattobd with incorrect configure macros.  This change adds MODULE_LICENSE to each test so that compilation doesn't fail even when a feature is truly present.