### PR TITLE
Add support for submit_bio to support newer kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ utils/update-img
 # Dynamically generated files
 src/kernel-config.h
 modules.order
+*.mod
 *.mod.c
 Module.symvers
 *.cmd
@@ -19,3 +20,5 @@ __pycache__/
 
 # Project directories
 pkgbuild/
+
+*kdev4*

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -23,3 +23,6 @@
 *.i*86
 *.x86_64
 *.hex
+
+# Debug symbols
+*.dwo

--- a/src/bio_helper.h
+++ b/src/bio_helper.h
@@ -5,6 +5,7 @@
  */
 
 #ifndef BIO_HELPER_H
+
 #define BIO_HELPER_H
 
 #include "includes.h"
@@ -20,6 +21,14 @@
 
 #define SECTORS_PER_BLOCK (COW_BLOCK_SIZE / SECTOR_SIZE)
 #define SECTOR_TO_BLOCK(sect) ((sect) / SECTORS_PER_BLOCK)
+
+#if !defined HAVE_MAKE_REQUEST_FN_IN_QUEUE && defined HAVE_BDOPS_SUBMIT_BIO
+        // Linux kernel version 5.9+
+        // make_request_fn has been moved from the request queue structure to the
+        // block_device_operations as submit_bio function.
+        // See https://github.com/torvalds/linux/commit/c62b37d96b6eb3ec5ae4cbe00db107bf15aebc93
+        #define USE_BDOPS_SUBMIT_BIO
+#endif
 
 // macros for working with bios
 #define BIO_SET_SIZE 256
@@ -164,6 +173,12 @@ void dattobd_bio_endio(struct bio *bio, int err);
 void dattobd_bio_endio(struct bio *bio, int err);
 #else
 void dattobd_bio_endio(struct bio *bio, int err);
+#endif
+
+#ifdef HAVE_BIO_BI_BDEV_BD_DISK
+    #define dattobd_bio_bi_disk(bio) ((bio)->bi_bdev->bd_disk)
+#else
+    #define dattobd_bio_bi_disk(bio) ((bio)->bi_disk)
 #endif
 
 #endif /* BIO_HELPER_H */

--- a/src/bio_request_callback.h
+++ b/src/bio_request_callback.h
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (C) 2022 Datto Inc.
+
+/**
+ *
+ * DOC: bio_request_callback header.
+ *
+ * Defines the various mechanisms and types needed to submit IO requests.
+ *
+ * Different types and callbacks are used between different versions of
+ * Linux in order to submit in-flight IO to the kernel.
+ *
+ * The purpose of this header is to provide a unified interface to making this
+ * happen.
+ */
+
+#ifndef BIO_REQUEST_CALLBACK_H_INCLUDE
+#define BIO_REQUEST_CALLBACK_H_INCLUDE
+
+#include "bio_helper.h" // needed for USE_BDOPS_SUBMIT_BIO to be defined
+#include "includes.h"
+#include "mrf.h"
+#include "submit_bio.h"
+
+#ifdef USE_BDOPS_SUBMIT_BIO
+#define BIO_REQUEST_TRACKING_PTR_TYPE const struct gendisk
+#define BIO_REQUEST_CALLBACK_FN submit_bio_fn
+#define SUBMIT_BIO_REAL dattobd_submit_bio_real
+#define GET_BIO_REQUEST_TRACKING_PTR dattobd_get_bd_submit_bio
+#define SET_BIO_REQUEST_TRACKING_PTR dattobd_set_bd_ops
+#else
+#define BIO_REQUEST_TRACKING_PTR_TYPE make_request_fn
+#define BIO_REQUEST_CALLBACK_FN make_request_fn
+#define SUBMIT_BIO_REAL dattobd_call_mrf_real
+#define GET_BIO_REQUEST_TRACKING_PTR dattobd_get_bd_mrf
+#define SET_BIO_REQUEST_TRACKING_PTR dattobd_set_bd_mrf
+#endif 
+
+#endif

--- a/src/bio_request_callback.h
+++ b/src/bio_request_callback.h
@@ -23,7 +23,7 @@
 #include "submit_bio.h"
 
 #ifdef USE_BDOPS_SUBMIT_BIO
-#define BIO_REQUEST_TRACKING_PTR_TYPE const struct gendisk
+#define BIO_REQUEST_TRACKING_PTR_TYPE struct gendisk
 #define BIO_REQUEST_CALLBACK_FN submit_bio_fn
 #define SUBMIT_BIO_REAL dattobd_submit_bio_real
 #define GET_BIO_REQUEST_TRACKING_PTR dattobd_get_bd_submit_bio
@@ -34,6 +34,6 @@
 #define SUBMIT_BIO_REAL dattobd_call_mrf_real
 #define GET_BIO_REQUEST_TRACKING_PTR dattobd_get_bd_mrf
 #define SET_BIO_REQUEST_TRACKING_PTR dattobd_set_bd_mrf
-#endif 
+#endif
 
 #endif

--- a/src/callback_refs.c
+++ b/src/callback_refs.c
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2022 Datto Inc.
+ */
+
+#include "callback_refs.h"
+
+struct gendisk_tracking_data {
+        const struct block_device *gtd_disk;
+        BIO_REQUEST_TRACKING_PTR_TYPE *gtd_orig;
+        atomic_t gtd_count;
+
+        struct hlist_node node;
+};
+
+#define MAX_BUCKETS_BITS 2 // 2^2 == 4
+DEFINE_HASHTABLE(gendisk_tracking_map, MAX_BUCKETS_BITS); 
+
+void gendisk_tracking_init(void) {
+        hash_init(gendisk_tracking_map);
+}
+
+static struct gendisk_tracking_data* get_a_node(const struct block_device *disk)
+{
+        unsigned int bkt = 0;
+        struct gendisk_tracking_data *cur = NULL;
+        hash_for_each(gendisk_tracking_map, bkt, cur, node) {
+                if (cur->gtd_disk == disk) {
+                        return cur;
+                }
+        }
+        return NULL;
+}
+
+int gendisk_fn_get(const struct block_device *disk, const BIO_REQUEST_TRACKING_PTR_TYPE *fn) 
+{
+        struct gendisk_tracking_data* gtd = get_a_node(disk);
+        if (!gtd) {
+                gtd = kzalloc(sizeof(struct gendisk_tracking_data), GFP_KERNEL);
+                if (!gtd) {
+                        return -ENOMEM;
+                }
+                gtd->gtd_disk = disk;
+                gtd->gtd_orig = (BIO_REQUEST_TRACKING_PTR_TYPE*) fn;
+                // kzalloc guarantees gtd->gtd_count = { 0 };
+                hash_add(gendisk_tracking_map, &gtd->node, (unsigned long)disk);
+        }
+
+        atomic_inc(&gtd->gtd_count);
+
+        return 0;
+}
+
+const BIO_REQUEST_TRACKING_PTR_TYPE* gendisk_fn_put(struct block_device *disk)
+{
+        BIO_REQUEST_TRACKING_PTR_TYPE *fn = NULL;
+        struct gendisk_tracking_data *gtd = get_a_node(disk);
+        if (!gtd) {
+                return NULL; // error here instead? essentially a double free
+        }
+
+        fn = gtd->gtd_orig;
+        if (atomic_dec_and_test(&gtd->gtd_count)) { // if gtd_count IS zero
+                hash_del(&gtd->node);
+                kfree(gtd);
+                return (const BIO_REQUEST_TRACKING_PTR_TYPE*) fn; // return the orig if this is our last ref
+        }
+        
+        // return the current mrf to make swap logic easier
+        return (const BIO_REQUEST_TRACKING_PTR_TYPE*) GET_BIO_REQUEST_TRACKING_PTR(disk);
+}
+
+size_t gendisk_fn_refcount(const BIO_REQUEST_TRACKING_PTR_TYPE *fn)
+{
+        unsigned int bkt = 0;
+        struct gendisk_tracking_data *cur = NULL;
+        size_t refcount = 0;
+        hash_for_each(gendisk_tracking_map, bkt, cur, node) {
+                if (cur->gtd_orig == fn) ++refcount;
+        }
+        return refcount;
+}

--- a/src/callback_refs.h
+++ b/src/callback_refs.h
@@ -28,6 +28,15 @@ void gendisk_tracking_init(void);
 int gendisk_fn_get(const struct block_device* disk, const BIO_REQUEST_TRACKING_PTR_TYPE* fn);
 
 /**
+ * gendisk_fn_lock() - locks the mutex for the given gendisk/mrf
+ *
+ * @disk: The block device to lock the gendisk/mrf for.
+ *
+ * Return: Returns 0 on success, non-zero otherwise.
+ */
+int gendisk_fn_lock(const struct block_device* disk);
+
+/**
  * gendisk_fn_put() - Decrements the reference count and returns gendisk/mrf
  *
  * @disk: The block device being tracked
@@ -44,5 +53,14 @@ const BIO_REQUEST_TRACKING_PTR_TYPE* gendisk_fn_put(struct block_device* disk);
  * Return: Returns the reference count for the given mrf or gendisk.
  */
 size_t gendisk_fn_refcount(const BIO_REQUEST_TRACKING_PTR_TYPE *fn);
+
+/**
+ * gendisk_fn_unlock() - unlocks the mutex for the given gendisk/mrf
+ *
+ * @disk: gendisk or mrf to unlock the gendisk/mrf for.
+ *
+ * Return: Returns 0 on success, non-zero otherwise.
+ */
+int gendisk_fn_unlock(const struct block_device* disk);
 
 #endif // CALLBACK_REFS_H_

--- a/src/callback_refs.h
+++ b/src/callback_refs.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2022 Datto Inc.
+ */
+
+#ifndef CALLBACK_REFS_H_
+#define CALLBACK_REFS_H_
+
+#include "includes.h"
+#include "bio_request_callback.h"
+
+/**
+ * gendisk_tracking_init() - Initialize gendisk/mrf tracking.
+ *
+ * Initializes the hash table used for gendisk/mrf reference counting.
+ */
+void gendisk_tracking_init(void);
+
+/**
+ * gendisk_fn_get() - Increments the reference count for given gendisk or mrf.
+ *
+ * @disk: The block device being tracked.
+ * @fn: The gendisk or mrf to inc the reference count for.
+ *
+ * Return: 0 on success. Non-zero otherwise.
+ */
+int gendisk_fn_get(const struct block_device* disk, const BIO_REQUEST_TRACKING_PTR_TYPE* fn);
+
+/**
+ * gendisk_fn_put() - Decrements the reference count and returns gendisk/mrf
+ *
+ * @disk: The block device being tracked
+ * 
+ * Return: Returns the mrf or gendisk for the block device or NULL on error.
+ */
+const BIO_REQUEST_TRACKING_PTR_TYPE* gendisk_fn_put(struct block_device* disk);
+
+/**
+ * gendisk_fn_refcount() - Get reference count for an mrf/gendisk
+ *
+ * @fn: The gendisk or make_request_fn to get the refcount for.
+ *
+ * Return: Returns the reference count for the given mrf or gendisk.
+ */
+size_t gendisk_fn_refcount(const BIO_REQUEST_TRACKING_PTR_TYPE *fn);
+
+#endif // CALLBACK_REFS_H_

--- a/src/configure-tests/feature-tests/bdops_submit_bio.c
+++ b/src/configure-tests/feature-tests/bdops_submit_bio.c
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2022 Datto Inc.
+ */
+
+// 5.9 <= kernel_version
+
+#include "includes.h"
+
+static blk_qc_t snap_submit_bio(struct bio *bio)
+{
+	return BLK_QC_T_NONE;
+}
+
+static inline void dummy(void){
+	struct bio b;
+	struct block_device_operations bdo = {
+		.submit_bio = snap_submit_bio,
+	};
+
+	bdo.submit_bio(&b);
+}

--- a/src/configure-tests/feature-tests/blk_mq_submit_bio.c
+++ b/src/configure-tests/feature-tests/blk_mq_submit_bio.c
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2022 Datto Inc.
+ */
+
+#include "includes.h"
+
+static inline void dummy(void){
+    struct bio b;
+    blk_mq_submit_bio(&b);
+}

--- a/src/configure-tests/feature-tests/make_request_fn_in_queue.c
+++ b/src/configure-tests/feature-tests/make_request_fn_in_queue.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2022 Datto Inc.
+ */
+
+// 5.8 <= kernel_version
+
+#include "includes.h"
+
+static inline void dummy(void){
+    make_request_fn *mk_rq_fn;
+    struct request_queue q = {
+        .make_request_fn = mk_rq_fn,
+    };
+    (void)q;
+}

--- a/src/configure-tests/feature-tests/thaw_bdev_int.c
+++ b/src/configure-tests/feature-tests/thaw_bdev_int.c
@@ -5,12 +5,13 @@
  */
 
 #include "includes.h"
+MODULE_LICENSE("GPL");
 
 MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
-	struct block_device bd;
-	struct super_block sb;
+    struct block_device bd;
+    struct super_block sb;
 
-	if(thaw_bdev(&bd, &sb)) bd.bd_private = 0;
+    if(thaw_bdev(&bd, &sb)) bd.bd_disk = 0;
 }

--- a/src/module_control.c
+++ b/src/module_control.c
@@ -8,6 +8,7 @@
 
 #include "dattobd.h"
 #include "includes.h"
+#include "callback_refs.h"
 #include "ioctl_handlers.h"
 #include "logging.h"
 #include "proc_seq_file.h"
@@ -304,6 +305,9 @@ static int __init agent_init(void)
         LOG_DEBUG("module init");
 
         mutex_init(&ioctl_mutex);
+
+        // gendisk ref hashtable init
+        gendisk_tracking_init();
 
         calc_max_snap_devices_and_init_minor_range();
 

--- a/src/mrf.c
+++ b/src/mrf.c
@@ -6,6 +6,7 @@
 
 #include "mrf.h"
 #include "includes.h"
+#include "snap_device.h"
 
 #ifdef HAVE_BLK_ALLOC_QUEUE
 //#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
@@ -26,7 +27,7 @@ int dattobd_call_mrf(make_request_fn *fn, struct request_queue *q,
         fn(q, bio);
         return 0;
 }
-#else
+#elif !defined USE_BDOPS_SUBMIT_BIO
 int dattobd_call_mrf(make_request_fn *fn, struct request_queue *q,
                      struct bio *bio)
 {
@@ -41,5 +42,57 @@ MRF_RETURN_TYPE dattobd_null_mrf(struct request_queue *q, struct bio *bio)
         percpu_ref_get(&q->q_usage_counter);
         // create a make_request_fn for the supplied request_queue.
         return blk_mq_make_request(q, bio);
+}
+#endif
+
+#ifndef HAVE_BDOPS_SUBMIT_BIO
+make_request_fn* dattobd_get_bd_mrf(struct block_device *bdev)
+{
+    return bdev->bd_disk->queue->make_request_fn;
+}
+
+void dattobd_set_bd_mrf(struct block_device *bdev, make_request_fn *mrf)
+{
+    bdev->bd_disk->queue->make_request_fn = mrf;
+}
+#endif
+
+#ifdef USE_BDOPS_SUBMIT_BIO
+MRF_RETURN_TYPE dattobd_null_mrf(struct bio *bio)
+{
+    // Before we can submit our bio to the original device... 
+    // If there's any bio in the bio_list that ISN'T our bio, requeue it and 
+    // return early, because that's what would happen anyway if we submit 
+    // the bio. submit_bio has a mechanism to prevent multiple bio's from 
+    // being active at once. This mechanism also messes us up, since 
+    // tracing_fn was already called from a submit_bio - so we have to clear
+    // the bio_list but only if the only bio in the list, is our bio... 
+    if (current->bio_list)
+    {
+        struct bio* bio_in_list = current->bio_list->head;
+        while (bio_in_list)
+        {
+            if (bio_in_list != bio)
+            {
+                bio_list_add(&current->bio_list[0], bio);
+                MRF_RETURN(0); // return BLK_QC_T_NONE;
+            }
+            bio_in_list = bio_in_list->bi_next;
+        }
+        current->bio_list = NULL; // don't free- it's stack allocated.
+    }
+    // Note, this is the global submit_bio - not the submit_bio function ptr
+    // that is a member of struct block_device_operations - because this is
+    // what we'll be using to submit IO to the real disk - the kernel's internal
+    // submit_bio impl. also knows to account for null function ptrs.
+    return submit_bio(bio);
+}
+#else
+int dattobd_call_mrf_real(struct snap_device *dev, struct bio *bio)
+{
+    return dattobd_call_mrf(
+        dev->sd_orig_request_fn,
+        dattobd_bio_get_queue(bio), 
+        bio);
 }
 #endif

--- a/src/mrf.h
+++ b/src/mrf.h
@@ -11,23 +11,28 @@
 #include "tracing_params.h"
 
 #ifdef HAVE_MAKE_REQUEST_FN_INT
+
 #define MRF_RETURN_TYPE int
 #define MRF_RETURN(ret) return ret
-
 int dattobd_call_mrf(make_request_fn *fn, struct request_queue *q,
                      struct bio *bio);
+
 #elif defined HAVE_MAKE_REQUEST_FN_VOID
+
 #define MRF_RETURN_TYPE void
 #define MRF_RETURN(ret) return
-
 int dattobd_call_mrf(make_request_fn *fn, struct request_queue *q,
                      struct bio *bio);
+
 #else
+
 #define MRF_RETURN_TYPE blk_qc_t
 #define MRF_RETURN(ret) return BLK_QC_T_NONE
-
+#ifndef USE_BDOPS_SUBMIT_BIO
 int dattobd_call_mrf(make_request_fn *fn, struct request_queue *q,
                      struct bio *bio);
+#endif // USE_BDOPS_SUBMIT_BIO
+
 #endif
 
 #if defined HAVE_BLK_ALLOC_QUEUE_2 || defined HAVE_BLK_ALLOC_QUEUE_RH_2
@@ -38,5 +43,28 @@ int dattobd_call_mrf(make_request_fn *fn, struct request_queue *q,
 //#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
 MRF_RETURN_TYPE dattobd_null_mrf(struct request_queue *q, struct bio *bio);
 #endif
+
+#ifdef USE_BDOPS_SUBMIT_BIO
+MRF_RETURN_TYPE dattobd_null_mrf(struct bio *bio);
+#else
+make_request_fn* dattobd_get_bd_mrf(struct block_device *bdev);
+void dattobd_set_bd_mrf(struct block_device *bdev, make_request_fn *mrf);
+#endif
+
+/**
+ * dattobd_call_mrf_real() - Submits i/o to the real/original device.
+ *
+ * This function submits i/o to the real/original make_request_fn (as opposed
+ * to the one we replaced for intercepting i/o) - we look up the mrf ptr from
+ * the snap_device which we saved when setting up tracking, and call it with
+ * our bio.
+ *
+ * @dev: the snap_device struct we set up with all of our state.
+ * @bio: the in-flight i/o to be submitted to the mrf.
+ *
+ * Returns:
+ * * Returns the result of the mrf function call as returned by dattobd_call_mrf
+ */
+int dattobd_call_mrf_real(struct snap_device *dev, struct bio *bio);
 
 #endif /* MRF_H_ */

--- a/src/paging_helper.c
+++ b/src/paging_helper.c
@@ -4,13 +4,31 @@
  * Copyright (C) 2022 Datto Inc.
  */
 
-#include "paging_helper.h"
 #include "includes.h"
+#include "paging_helper.h"
 
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,22)
 #ifndef X86_CR0_WP
 #define X86_CR0_WP (1UL << 16)
 #endif
+
+/**
+ * wp_cr0 - Sets the cr0 cpu register to given value.
+ *
+ * Enabling/disabling approach with usage of the write_cr0 function stopped
+ * working sometime around Linux kernels 5.X (maybe 5.3) after this patch:
+ * https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8dbec27a242cd3e2816eeb98d3237b9f57cf6232
+ * ... hence this wrapper which does a straight up mov for >= 5.9 ; for older
+ * kernels we keep write_cr0().
+ *
+ */
+static inline void wp_cr0(unsigned long cr0) {
+#ifdef USE_BDOPS_SUBMIT_BIO
+        __asm__ __volatile__ ("mov %0, %%cr0": "+r" (cr0));
+#else
+        write_cr0(cr0);
+#endif
+}
 
 /**
  * disable_page_protection() - Clears the WP flag in the CR0 register.  This
@@ -19,10 +37,9 @@
  * @cr0: Output resulting from reading the CR0 register before making any
  *       modifications.
  */
-void disable_page_protection(unsigned long *cr0)
-{
+void disable_page_protection(unsigned long* cr0) {
         *cr0 = read_cr0();
-        write_cr0(*cr0 & ~X86_CR0_WP);
+        wp_cr0(*cr0 & ~X86_CR0_WP);
 }
 
 /**

--- a/src/proc_seq_file.c
+++ b/src/proc_seq_file.c
@@ -1,9 +1,3 @@
-// SPDX-License-Identifier: GPL-2.0-only
-
-/*
- * Copyright (C) 2022 Datto Inc.
- */
-
 #include "cow_manager.h"
 #include "dattobd.h"
 #include "includes.h"
@@ -44,16 +38,33 @@ static const struct seq_operations dattobd_seq_proc_ops = {
         .show = dattobd_proc_show,
 };
 
+#ifndef HAVE_PROC_OPS
+
 /**
  * get_proc_fops() - Retrieves a file operations struct pointer
  *
  * Return:
  * The &struct file_operations object pointer.
  */
-const struct file_operations *get_proc_fops(void)
+const struct file_operations* get_proc_fops(void)
 {
         return &dattobd_proc_fops;
 }
+
+#else // HAVE_PROC_OPS
+
+/**
+ * get_proc_fops() - Retrieves a file operations struct pointer
+ *
+ * Return:
+ * The &struct file_operations object pointer.
+ */
+const struct proc_ops* get_proc_fops(void)
+{
+        return &dattobd_proc_fops;
+}
+
+#endif // HAVE_PROC_OPS
 
 /**
  * dattobd_proc_get_idx() - Turns offset into pointer into @snap_devices array.
@@ -88,7 +99,7 @@ static void *dattobd_proc_start(struct seq_file *m, loff_t *pos)
          * be called followed by an invocation of this function with a non-
          * zero @pos with the expectation that we continue from where we
          * left off.
-         */
+         */ 
         if (*pos == 0)
                 return SEQ_START_TOKEN;
         return dattobd_proc_get_idx(*pos - 1);

--- a/src/proc_seq_file.h
+++ b/src/proc_seq_file.h
@@ -8,7 +8,6 @@
 #define PROC_SEQ_FILE_H_
 
 #ifndef HAVE_PROC_OPS
-//#if LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0)
 const struct file_operations *get_proc_fops(void);
 #else
 const struct proc_ops *get_proc_fops(void);

--- a/src/snap_device.h
+++ b/src/snap_device.h
@@ -7,8 +7,11 @@
 #ifndef SNAP_DEVICE_H_
 #define SNAP_DEVICE_H_
 
+#include "bio_helper.h" // needed for USE_BDOPS_SUBMIT_BIO to be defined
 #include "bio_queue.h"
+#include "bio_request_callback.h"
 #include "includes.h"
+#include "submit_bio.h"
 #include "sset_queue.h"
 
 // macros for defining the state of a tracing struct (bit offsets)
@@ -28,15 +31,23 @@ struct snap_device {
         sector_t sd_size; // size of device in sectors
         struct request_queue *sd_queue; // snap device request queue
         struct gendisk *sd_gd; // snap device gendisk
+#ifdef USE_BDOPS_SUBMIT_BIO
+        // Block device's gendisk structure holding the original submit_bio.
+        struct gendisk *sd_orig_gendisk;
+        struct blk_mq_tag_set *sd_tag_set;
+        // Gendisk structure used for tracing with the submit_bio function
+        // pointer set to our own tracing callback.
+        struct gendisk *sd_tracing_gendisk;
+        // Original bdops (fops member of gendisk from orig. device).
+        struct block_device_operations* sd_orig_fops;
+#endif
         struct block_device *sd_base_dev; // device being snapshot
         char *sd_bdev_path; // base device file path
         struct cow_manager *sd_cow; // cow manager
         char *sd_cow_path; // cow file path
         struct inode *sd_cow_inode; // cow file inode
-        make_request_fn *sd_orig_mrf; // block device's original make request
-                                      // function
-        struct task_struct *sd_cow_thread; // thread for handling file
-                                           // read/writes
+        BIO_REQUEST_CALLBACK_FN *sd_orig_request_fn; // block device's original make_request_fn or submit_bio function ptr.
+        struct task_struct *sd_cow_thread; // thread for handling file read/writes
         struct bio_queue sd_cow_bios; // list of outstanding cow bios
         struct task_struct *sd_mrf_thread; // thread for handling file
                                            // read/writes

--- a/src/snap_handle.c
+++ b/src/snap_handle.c
@@ -131,6 +131,9 @@ int snap_handle_read_bio(const struct snap_device *dev, struct bio *bio)
 
         // submit the bio to the base device and wait for completion
         if (mode != READ_MODE_COW_FILE) {
+#ifdef HAVE_BDOPS_SUBMIT_BIO
+                bio->bi_disk = dev->sd_orig_gendisk;
+#endif
                 ret = dattobd_submit_bio_wait(bio);
                 if (ret) {
                         LOG_ERROR(ret,

--- a/src/snap_ops.c
+++ b/src/snap_ops.c
@@ -9,6 +9,7 @@
 #include "includes.h"
 #include "logging.h"
 #include "snap_device.h"
+#include "tracer_helper.h"
 
 /**
  * __tracer_add_ref() - Adds a reference to &snap_device->sd_refs.
@@ -75,10 +76,40 @@ static void snap_release(struct gendisk *gd, fmode_t mode)
 }
 #endif
 
+#ifndef USE_BDOPS_SUBMIT_BIO
+// Linux version < 5.9
+MRF_RETURN_TYPE snap_mrf(struct request_queue *q, struct bio *bio){
+    struct snap_device *dev = q->queuedata;
+#else
+// Linux version >= 5.9
+MRF_RETURN_TYPE snap_mrf(struct bio *bio){
+    struct snap_device *dev = dattobd_bio_bi_disk(bio)->queue->queuedata;
+#endif
+    //if a write request somehow gets sent in, discard it
+    if(bio_data_dir(bio)){
+        dattobd_bio_endio(bio, -EOPNOTSUPP);
+        MRF_RETURN(0);
+    }else if(tracer_read_fail_state(dev)){
+        dattobd_bio_endio(bio, -EIO);
+        MRF_RETURN(0);
+    }else if(!test_bit(ACTIVE, &dev->sd_state)){
+        dattobd_bio_endio(bio, -EBUSY);
+        MRF_RETURN(0);
+    }
+
+    //queue bio for processing by kernel thread
+    bio_queue_add(&dev->sd_cow_bios, bio);
+
+    MRF_RETURN(0);
+}
+
 static const struct block_device_operations snap_ops = {
         .owner = THIS_MODULE,
         .open = snap_open,
         .release = snap_release,
+#ifdef USE_BDOPS_SUBMIT_BIO
+        .submit_bio = snap_mrf
+#endif
 };
 
 const struct block_device_operations *get_snap_ops(void)

--- a/src/snap_ops.h
+++ b/src/snap_ops.h
@@ -6,6 +6,16 @@
 #ifndef SNAP_OPS_H_
 #define SNAP_OPS_H_
 
+#include "mrf.h"
+
 const struct block_device_operations *get_snap_ops(void);
+
+#ifndef USE_BDOPS_SUBMIT_BIO
+// Linux version < 5.9
+MRF_RETURN_TYPE snap_mrf(struct request_queue *q, struct bio *bio);
+#else
+// Linux version >= 5.9
+MRF_RETURN_TYPE snap_mrf(struct bio *bio);
+#endif
 
 #endif /* SNAP_OPS_H_ */

--- a/src/submit_bio.c
+++ b/src/submit_bio.c
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2022 Datto Inc.
+ */
+
+#include "submit_bio.h"
+
+#include "bio_helper.h" // needed for USE_BDOPS_SUBMIT_BIO to be defined
+#include "includes.h"
+#include "logging.h"
+#include "paging_helper.h"
+#include "snap_device.h"
+
+#ifdef USE_BDOPS_SUBMIT_BIO
+
+int dattobd_submit_bio_real(
+    struct snap_device* dev,
+    struct bio *bio)
+{
+    BIO_REQUEST_CALLBACK_FN *fn = NULL;
+    if (!dev)
+    {
+        LOG_ERROR(-EFAULT,
+                  "Missing snap_device when calling dattobd_call_submit_bio");
+        return -EFAULT;
+    }
+    fn = dev->sd_orig_request_fn;
+    if (!fn)
+    {
+        LOG_ERROR(-EFAULT, "error finding original_mrf");
+        return -EFAULT;
+    }
+    bio->bi_disk = dev->sd_orig_gendisk;
+    return fn(bio);
+}
+
+submit_bio_fn* dattobd_get_bd_submit_bio(struct block_device *bdev)
+{
+    return bdev->bd_disk->fops->submit_bio;
+}
+
+struct gendisk* dattobd_get_gendisk(const struct block_device *bd_dev)
+{
+    return bd_dev->bd_disk;
+}
+
+void dattobd_set_submit_bio(struct block_device *bdev, submit_bio_fn *func)
+{
+    unsigned long cr0 = 0;
+    preempt_disable();
+    disable_page_protection(&cr0);
+    ((struct block_device_operations*)bdev->bd_disk->fops)->submit_bio = func;
+    reenable_page_protection(&cr0);
+    preempt_enable();
+}
+
+struct block_device_operations* dattobd_copy_block_device_operations(
+    struct block_device_operations* fops,
+    submit_bio_fn* submit_bio_fn)
+{
+    const size_t block_device_operations_size = sizeof(
+        struct block_device_operations);
+    struct block_device_operations* result = kmalloc(
+        block_device_operations_size,
+        GFP_KERNEL
+    );
+    memcpy(result, fops, block_device_operations_size);
+    result->owner = THIS_MODULE;
+    result->submit_bio = submit_bio_fn;
+    return result;
+}
+
+struct gendisk* dattobd_copy_gendisk(
+    struct gendisk* bi_disk,
+    submit_bio_fn* submit_bio_fn)
+{
+    const size_t gendisk_size = sizeof(struct gendisk);
+    struct gendisk* result = kmalloc(gendisk_size, GFP_KERNEL);
+    memcpy(result, bi_disk, gendisk_size); // Initial shallow copy.
+
+    // Shallow copy of the fops struct.
+    result->fops = dattobd_copy_block_device_operations(
+        (struct block_device_operations*) bi_disk->fops,
+        submit_bio_fn
+    ); 
+
+    return result;
+}
+
+void dattobd_set_bd_ops(
+    struct block_device *bdev,
+    const struct block_device_operations *bd_ops)
+{
+    bdev->bd_disk->fops = bd_ops;
+}
+
+void dattobd_set_gendisk(
+    struct block_device *bdev,
+    const struct gendisk* bd_disk
+)
+{
+    bdev->bd_disk = (struct gendisk*)bd_disk;
+}
+
+
+#endif

--- a/src/submit_bio.c
+++ b/src/submit_bio.c
@@ -32,6 +32,11 @@ int dattobd_submit_bio_real(
         return -EFAULT;
     }
     bio->bi_disk = dev->sd_orig_gendisk;
+    LOG_DEBUG(
+            "SUBMIT_BIO_REAL | bdev path: %s | bio partno: %d | ",
+            dev->sd_bdev_path,
+            bio->bi_partno
+    );
     return fn(bio);
 }
 

--- a/src/submit_bio.h
+++ b/src/submit_bio.h
@@ -117,6 +117,7 @@ struct block_device_operations* dattobd_copy_block_device_operations(
  * dattobd_copy_block_device_operations() to make a copy of the fops member, but
  * with the submit_bio function pointer replaced with the one provided.
  *
+ * @bdev: block device of the device being snapshotted.
  * @bi_disk: gendisk to be copied. This would typically be a ptr to the 
  *           real/orig device's gendisk.
  * @submit_bio_fn: Function pointer to set the new gendisk's fops->submit_bio to
@@ -127,6 +128,7 @@ struct block_device_operations* dattobd_copy_block_device_operations(
  * * Returns a pointer to the newly created gendisk struct.
  */
 struct gendisk* dattobd_copy_gendisk(
+    struct block_device* bdev,
     struct gendisk* bi_disk,
     submit_bio_fn* submit_bio_fn);
 

--- a/src/submit_bio.h
+++ b/src/submit_bio.h
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2022 Datto Inc.
+ */
+
+/**
+ * This defines a set of helper functions to work with the submit_bio function
+ * pointer and the gendisk / block_device_operations structs that hold it.
+ *
+ * This is the mechanism we use to intercept in-flight i/o on kernels >= 5.9.
+ * Kernels older than that use make_request_function instead.
+ *
+ * The general approach here is that we make a copy of the gendisk of the
+ * original disk, and replace the fops->submit_bio function pointer with a 
+ * pointer to our own tracing_fn
+ *
+ * One gotcha here is that there is one gendisk for the entire device. So we
+ * have to make sure we save the original one and replace it back whenever we
+ * want to do i/o to the real device in order to avoid endless recursion. For
+ * this reason we store pointers to the real/orig gendisk and the tracing
+ * gendisk in our snap_device struct.
+ */
+
+#ifndef SUBMIT_BIO_H_
+#define SUBMIT_BIO_H_
+
+#include "includes.h"
+#include "bio_helper.h" // needed for USE_BDOPS_SUBMIT_BIO to be defined
+
+struct snap_device;
+
+#ifdef USE_BDOPS_SUBMIT_BIO
+
+/**
+ * submit_bio_fn() - Prototype for the submit_bio function, which will be our
+ * hook to intercept IO on kernels >= 5.9 
+ */
+typedef blk_qc_t (submit_bio_fn) (struct bio *bio);
+
+/**
+ * dattobd_submit_bio_real() - Submit's given bio to the real device 
+ *                            (as opposed to our driver).
+ *
+ * @dev: Pointer to the snap_device that keeps device state.
+ * @bio: Pointer to the bio struct which describes the in-flight I/O.
+ *
+ * Return:
+ * * 0 - success
+ * * !0 - error
+ */
+int dattobd_submit_bio_real(
+    struct snap_device* dev,
+    struct bio *bio
+);
+
+/**
+ * dattobd_get_bd_submit_bio() - Return the submit_bio function pointer attached
+ *                               to the device of given bio.
+ *
+ * @bdev: The block device for which to get the submit_bio function pointer.
+ *
+ * Return:
+ * * Returns a submit_bio function pointer.
+ */
+submit_bio_fn* dattobd_get_bd_submit_bio(struct block_device *bdev);
+
+/**
+ * dattobd_get_gendisk() - Get a block device's gendisk struct.
+ *
+ * @bd_dev: The block device to get the gendisk struct for.
+ *
+ * Return:
+ * * Returns a pointer to the block device's gendisk struct.
+ */
+struct gendisk* dattobd_get_gendisk(const struct block_device *bd_dev);
+
+/**
+ * dattobd_set_submit_bio() -  Assign the submit_bio function pointer in a block
+ *                             device.
+ *
+ * @bdev: The block device to set the submit_bio function pointer for.
+ * @func: Function pointer to set the submit_bio function pointer to.
+ */
+void dattobd_set_submit_bio(struct block_device *bdev, submit_bio_fn *func);
+
+/**
+ * dattobd_copy_block_device_operations() - Copy original device's 
+ *                                          block_device_operations struct into
+ *                                          one that can be used for tracing.
+ * 
+ * In kernels >= 5.9, this is used to create a block_device_operations struct to
+ * be used within the tracing gendisk. It shallow-copies the 
+ * block_device_operations structure, within the given block device and replaces
+ * the submit_bio function pointer in the copy with the one provided. It also
+ * sets the owner to this module.
+ *
+ * @fops: pointer to block_device_operations structure to copy, this would 
+ *        normally be the gendisk->fops member of the original/real disk.
+ * @submit_bio_fn: The submit_bio function pointer to set in the copy, this
+ *                 would typically be tracing_fn so we can intercept io in the
+ *                 tracing gendisk.
+ *
+ * Return:
+ * * Returns a pointer to the newly created block_device_operations struct.
+ */
+struct block_device_operations* dattobd_copy_block_device_operations(
+    struct block_device_operations* fops,
+    submit_bio_fn* submit_bio_fn
+);
+
+/**
+ * dattobd_copy_gendisk() - Copy the original devices gendisk struct into one
+ *                        that can be used for tracing.
+ *
+ * Does a shallow copy of the gendisk struct itself, and calls 
+ * dattobd_copy_block_device_operations() to make a copy of the fops member, but
+ * with the submit_bio function pointer replaced with the one provided.
+ *
+ * @bi_disk: gendisk to be copied. This would typically be a ptr to the 
+ *           real/orig device's gendisk.
+ * @submit_bio_fn: Function pointer to set the new gendisk's fops->submit_bio to
+ *                 - typically this would be tracing_fn to make a gendisk for
+ *                 tracing that intercepts in-flight i/o.
+ *
+ * Return:
+ * * Returns a pointer to the newly created gendisk struct.
+ */
+struct gendisk* dattobd_copy_gendisk(
+    struct gendisk* bi_disk,
+    submit_bio_fn* submit_bio_fn);
+
+/**
+ * dattobd_set_bd_ops() -  Set the block device operations struct pointer in a
+ *                         block device.
+ *
+ * @bdev: Pointer to block_device struct to set the bd_ops member for.
+ * @bd_ops: Pointer to block_device_operations struct that will be assigned to
+ *          the block_device's bd_ops member.
+ */
+void dattobd_set_bd_ops(
+    struct block_device *bdev,
+    const struct block_device_operations *bd_ops);
+
+/**
+ * dattobd_set_gendisk() - Sets the gendisk for a block device.
+ *
+ * @bdev: Block device to set the gendisk for.
+ * @bd_disk: Pointer to gendisk struct that will be assigned to the
+ *           block_device's bd_disk member.
+ */
+void dattobd_set_gendisk(
+    struct block_device *bdev,
+    const struct gendisk* bd_disk
+);
+
+#endif // USE_BDOPS_SUBMIT_BIO
+#endif // SUBMIT_BIO_H_

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -5,6 +5,8 @@
  */
 
 #include "tracer.h"
+
+#include "bio_request_callback.h"
 #include "blkdev.h"
 #include "cow_manager.h"
 #include "filesystem.h"
@@ -15,12 +17,13 @@
 #include "mrf.h"
 #include "snap_device.h"
 #include "snap_ops.h"
+#include "submit_bio.h"
 #include "task_helper.h"
 #include "tracer_helper.h"
-
+#include "tracing_params.h"
+#include <linux/blk-mq.h>
 #ifdef HAVE_BLK_ALLOC_QUEUE
 //#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
-#include <linux/blk-mq.h>
 #include <linux/percpu-refcount.h>
 #endif
 
@@ -72,7 +75,19 @@ static int bdev_stack_limits(struct queue_limits *t, struct block_device *bdev,
 #else
 #define dattobd_bdev_stack_limits(queue, bdev, start)                          \
         bdev_stack_limits(&(queue)->limits, bdev, start)
+#endif // # !HAVE_BDEV_STACK_LIMITS) && !HAVE_BLK_SET_DEFAULT_LIMITS
+
+// Helpers to get/set either the make_request_fn or the submit_bio function 
+// pointers in a block device.
+static inline BIO_REQUEST_CALLBACK_FN* dattobd_get_bd_fn(
+    struct block_device *bdev)
+{
+#ifdef USE_BDOPS_SUBMIT_BIO
+    return bdev->bd_disk->fops->submit_bio;
+#else
+    return bdev->bd_disk->queue->make_request_fn;
 #endif
+}
 
 #ifndef HAVE_BLK_SET_DEFAULT_LIMITS
 #define blk_set_default_limits(ql)
@@ -128,28 +143,18 @@ static int bdev_stack_limits(struct queue_limits *t, struct block_device *bdev,
 #define SECTORS_PER_PAGE (PAGE_SIZE / SECTOR_SIZE)
 #define BLOCK_TO_SECTOR(block) ((block)*SECTORS_PER_BLOCK)
 
-MRF_RETURN_TYPE snap_mrf(struct request_queue *q, struct bio *bio)
+void dattobd_free_request_tracking_ptr(struct snap_device *dev)
 {
-        struct snap_device *dev = q->queuedata;
-
-        // if a write request somehow gets sent in, discard it
-        if (bio_data_dir(bio)) {
-                dattobd_bio_endio(bio, -EOPNOTSUPP);
-                MRF_RETURN(0);
-        } else if (tracer_read_fail_state(dev)) {
-                dattobd_bio_endio(bio, -EIO);
-                MRF_RETURN(0);
-        } else if (!test_bit(ACTIVE, &dev->sd_state)) {
-                dattobd_bio_endio(bio, -EBUSY);
-                MRF_RETURN(0);
-        }
-
-        // queue bio for processing by kernel thread
-        bio_queue_add(&dev->sd_cow_bios, bio);
-
-        MRF_RETURN(0);
+    dev->sd_orig_request_fn = NULL;
+#ifdef USE_BDOPS_SUBMIT_BIO
+    dev->sd_orig_gendisk = NULL;
+    if (dev->sd_tracing_gendisk) {
+        kfree(dev->sd_tracing_gendisk);
+        dev->sd_tracing_gendisk = NULL;
+    }
+#endif
 }
-
+ 
 /**
  * snap_trace_bio() - Traces a bio when snapshotting.  For bio reads there is
  * nothing to do and the request is passed to the original driver.  For writes
@@ -174,18 +179,18 @@ static int snap_trace_bio(struct snap_device *dev, struct bio *bio)
 
         // if we don't need to cow this bio just call the real mrf normally
         if (!bio_needs_cow(bio, dev->sd_cow_inode))
-                return dattobd_call_mrf(dev->sd_orig_mrf,
-                                        dattobd_bio_get_queue(bio), bio);
-
+        {
+                return SUBMIT_BIO_REAL(dev, bio);
+        }
         // the cow manager works in 4096 byte blocks, so read clones must also
         // be 4096 byte aligned
         start_sect = ROUND_DOWN(bio_sector(bio) - dev->sd_sect_off,
-                                SECTORS_PER_BLOCK) +
-                     dev->sd_sect_off;
+                        SECTORS_PER_BLOCK) +
+                dev->sd_sect_off;
         end_sect = ROUND_UP(bio_sector(bio) + (bio_size(bio) / SECTOR_SIZE) -
-                                    dev->sd_sect_off,
-                            SECTORS_PER_BLOCK) +
-                   dev->sd_sect_off;
+                        dev->sd_sect_off,
+                        SECTORS_PER_BLOCK) +
+                dev->sd_sect_off;
         pages = (end_sect - start_sect) / SECTORS_PER_PAGE;
 
         // allocate tracing_params struct to hold all pointers we will need
@@ -198,7 +203,7 @@ retry:
         // allocate and populate read bio clone. This bio may not have all the
         // pages we need due to queue restrictions
         ret = bio_make_read_clone(dev_bioset(dev), tp, bio, start_sect, pages,
-                                  &new_bio, &bytes);
+                        &new_bio, &bytes);
         if (ret)
                 goto error;
 
@@ -278,7 +283,8 @@ static int inc_make_sset(struct snap_device *dev, sector_t sect,
 /**
  * inc_trace_bio() - Determines the regions modified by the @bio and
  * queues their affected regions so that a record of what changed can be
- * kept.  The bio is then processed by the original mrf so that the
+ * kept.  The bio is then processed by the original io submit function
+ * (make_request_fn or submit_bio function ptr) so that the
  * modification can be made permanent.  This mode of tracing only
  * records what has changed and does not COW data.
  *
@@ -338,8 +344,7 @@ out:
         }
 
         // call the original mrf
-        ret = dattobd_call_mrf(dev->sd_orig_mrf, dattobd_bio_get_queue(bio),
-                               bio);
+        ret = SUBMIT_BIO_REAL(dev, bio);
 
         return ret;
 }
@@ -783,7 +788,6 @@ static int snap_merge_bvec(struct request_queue *q, struct bio *bio_bvm,
 
         return base_queue->merge_bvec_fn(base_queue, bio_bvm, bvec);
 }
-
 #endif
 #endif
 
@@ -847,10 +851,14 @@ error:
 }
 
 /**
- * __tracer_copy_cow_path() - Copies the COW path from @src to @dest.
+ * __tracer_setup_cow_path() - Sets up the COW file path given a &struct file.
  *
- * @src: The &struct snap_device source object pointer.
- * @dest: The &struct snap_device destination object pointer.
+ * @dev: The &struct snap_device object pointer.
+ * @cow_file: The &struct file object pointer.
+ *
+ * Return:
+ * * 0 - success
+ * * !0 - errno indicating the error
  */
 static void __tracer_copy_cow_path(const struct snap_device *src,
                                    struct snap_device *dest)
@@ -931,6 +939,21 @@ static int __tracer_bioset_init(struct snap_device *dev)
 #endif
 }
 
+static blk_status_t tracing_queue_rq(struct blk_mq_hw_ctx *hctx, 
+        const struct blk_mq_queue_data *bd)
+{
+        struct request *rq = bd->rq;
+        blk_mq_start_request(rq);
+        blk_mq_complete_request(rq);
+        return BLK_STS_OK;
+}
+
+static const struct blk_mq_ops tracing_mq_ops = {
+    .queue_rq = tracing_queue_rq,
+    .init_request = NULL, // move snap thread initialization here?
+    .complete = NULL
+}; /// @todo move me somewhere appropriate along with the rest of the mq stuff.
+
 /**
  * __tracer_setup_snap() - Allocates &struct snap_device fields for use when
  *                         tracking an active snapshot.  Also sets up the
@@ -951,7 +974,7 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor,
                                struct block_device *bdev, sector_t size)
 {
         int ret;
-
+        
         ret = __tracer_bioset_init(dev);
         if (ret) {
                 LOG_ERROR(ret, "error initializing bio set");
@@ -959,7 +982,7 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor,
         }
 
         // allocate request queue
-        LOG_DEBUG("allocating queue");
+        LOG_DEBUG("allocating queue"); 
 #ifndef HAVE_BLK_ALLOC_QUEUE
         //#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)
         dev->sd_queue = blk_alloc_queue(GFP_KERNEL);
@@ -976,11 +999,52 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor,
                 goto error;
         }
 
+#ifdef USE_BDOPS_SUBMIT_BIO
+        // allocate tag set
+        LOG_DEBUG("allocating tag set");
+        dev->sd_tag_set = kzalloc_node(
+            sizeof(struct blk_mq_tag_set),
+            GFP_KERNEL, NUMA_NO_NODE);
+        
+        dev->sd_tag_set->ops = &tracing_mq_ops;
+        dev->sd_tag_set->nr_hw_queues = 1;
+        dev->sd_tag_set->queue_depth = 128; // must be < BLK_MQ_MAX_DEPTH
+        dev->sd_tag_set->numa_node = NUMA_NO_NODE;
+        // cmd_size not set
+        dev->sd_tag_set->flags = BLK_MQ_F_SHOULD_MERGE | BLK_MQ_F_STACKING;       
+        // driver_data not set.
+        ret = blk_mq_alloc_tag_set(dev->sd_tag_set);
+        if (ret)
+        {
+            LOG_ERROR(ret, "could not allocate tag set");
+            goto error;
+        }
+        // init queue
+        LOG_DEBUG("initializing queue");
+        dev->sd_queue = blk_mq_init_allocated_queue(
+            dev->sd_tag_set,
+            dev->sd_queue,
+            true
+        );        
+#endif
+        if (IS_ERR(dev->sd_queue)) {
+            LOG_ERROR( (int)PTR_ERR(dev->sd_queue), "error initializing tag set");
+            goto error;
+        } 
+
+// For the Linux kernel version 5.9+:
+// The snap_mrf function is already set in the block_device_operations snap_ops struct
+// as submit_bio func. So, the request handler is already registered.
+// See a line below "dev->sd_gd->fops = &snap_ops;"
 #ifndef HAVE_BLK_ALLOC_QUEUE
         //#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)
         // register request handler
+        
+        
+#ifndef USE_BDOPS_SUBMIT_BIO
         LOG_DEBUG("setting up make request function");
         blk_queue_make_request(dev->sd_queue, snap_mrf);
+#endif
 #endif
 
         // give our request queue the same properties as the base device's
@@ -1056,9 +1120,7 @@ error:
 }
 
 /**
- * __tracer_destroy_cow_thread() - Stops the COW kernel thread and
- *                                 disassociates it from the
- *                                 &struct snap_device.
+ * __tracer_bioset_exit() - Releases the bioset within the &struct snap_device.
  *
  * @dev: The &struct snap_device object pointer.
  */
@@ -1120,140 +1182,274 @@ error:
  *
  * @dev: The &struct snap_device object pointer.
  * @bdev: The &struct block_device that stores the COW data.
- * @new_mrf: Optional MRF function to be used by the snapshot disk,
- *           may be NULL to continue using the current MRF fn.
+ * @new_bio_tracking_ptr: Optional function pointer to be used by the snapshot disk
+ *         i/o handling, may be NULL to continue using the current function pointer.
  * @dev_ptr: Contains the output &struct snap_device when successful.
  *
  * Return:
  * * 0 - success
  * * !0 - errno indicating the error
  */
-static int __tracer_transition_tracing(struct snap_device *dev,
-                                       struct block_device *bdev,
-                                       make_request_fn *new_mrf,
-                                       struct snap_device **dev_ptr)
+static int __tracer_transition_tracing(
+    struct snap_device *dev,
+    struct block_device *bdev,
+    BIO_REQUEST_TRACKING_PTR_TYPE *new_bio_tracking_ptr,
+    struct snap_device **dev_ptr)
 {
         int ret;
         struct super_block *origsb = dattobd_get_super(bdev);
+        #ifndef HAVE_FREEZE_SUPER
         struct super_block *sb = NULL;
+        #endif
         char bdev_name[BDEVNAME_SIZE];
         MAYBE_UNUSED(ret);
 
         bdevname(bdev, bdev_name);
+        if(origsb){
 
-        if (origsb) {
-                // freeze and sync block device
+                //freeze and sync block device
                 LOG_DEBUG("freezing '%s'", bdev_name);
+#ifdef HAVE_FREEZE_SUPER
+//#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,34)
+                ret = freeze_super(origsb);
+                if (ret){
+                        LOG_ERROR((ret), "error freezing super for '%s': error", bdev_name);
+                        dattobd_drop_super(origsb);
+                        return ret;
+                }
+#else
                 sb = freeze_bdev(bdev);
-                if (!sb) {
+                if(!sb){
                         LOG_ERROR(-EFAULT, "error freezing '%s': null",
                                   bdev_name);
                         dattobd_drop_super(origsb);
                         return -EFAULT;
-                } else if (IS_ERR(sb)) {
+                }else if(IS_ERR(sb)){
                         LOG_ERROR((int)PTR_ERR(sb),
                                   "error freezing '%s': error", bdev_name);
                         dattobd_drop_super(origsb);
                         return (int)PTR_ERR(sb);
                 }
+#endif
         }
-
+        else{
+                LOG_WARN(
+                        "warning: no super found for device '%s', "
+                        "unable to freeze it",
+                        bdev_name);
+        }
         smp_wmb();
-        if (dev) {
+        if(dev){
                 LOG_DEBUG("starting tracing");
                 *dev_ptr = dev;
                 smp_wmb();
-                if (new_mrf)
-                        bdev->bd_disk->queue->make_request_fn = new_mrf;
-        } else {
-                LOG_DEBUG("ending tracing");
-#ifndef HAVE_BLK_ALLOC_QUEUE
-                //#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)
-                if (new_mrf)
-                        bdev->bd_disk->queue->make_request_fn = new_mrf;
+                if(new_bio_tracking_ptr){
+#ifdef USE_BDOPS_SUBMIT_BIO            
+                        dattobd_set_gendisk(bdev, new_bio_tracking_ptr);
 #else
-                if (new_mrf)
-                        bdev->bd_disk->queue->make_request_fn =
-                                new_mrf == dattobd_null_mrf ? NULL : new_mrf;
+                        bdev->bd_disk->queue->make_request_fn = 
+                                new_bio_tracking_ptr;
 #endif
-                smp_wmb();
-                *dev_ptr = dev;
-        }
-        smp_wmb();
-
-        if (origsb) {
-                // thaw the block device
-                LOG_DEBUG("thawing '%s'", bdev_name);
-#ifndef HAVE_THAW_BDEV_INT
-                //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,29)
-                thaw_bdev(bdev, sb);
+                }
+        }else{
+                LOG_DEBUG("ending tracing");
+                if (new_bio_tracking_ptr){
+#ifdef USE_BDOPS_SUBMIT_BIO
+                        dattobd_set_gendisk(bdev, new_bio_tracking_ptr);
 #else
+                        bdev->bd_disk->queue->make_request_fn =
+                                new_bio_tracking_ptr;
+#endif
+                }
+                *dev_ptr = dev;
+                smp_wmb();
+        }
+        if(origsb){
+                //, the block device
+                LOG_DEBUG("thawing '%s'", bdev_name);
+#ifdef HAVE_THAW_BDEV_INT
                 ret = thaw_bdev(bdev, sb);
-                if (ret) {
+#else
+                ret = thaw_bdev(bdev);
+#endif
+                if(ret){
                         LOG_ERROR(ret, "error thawing '%s'", bdev_name);
-                        // we can't reasonably undo what we've done at this
-                        // point, and we've replaced the mrf. pretend we
+                        // We can't reasonably undo what we've done at this 
+                        // point, and we've replaced the mrf. pretend we 
                         // succeeded so we don't break the block device
                 }
-#endif
                 dattobd_drop_super(origsb);
         }
-
         return 0;
 }
 
-/**
- * tracing_mrf() - Routes the BIO to the appropriate MRF function.
- * @q: The &struct request_queue.
- * @bio: The &struct bio which describes the I/O.
+#ifdef USE_BDOPS_SUBMIT_BIO
+
+/**     
+ * tracing_fn() - This is the entry point for in-flight i/o we intercepted.
+ * @bio: The &struct bio which describes the in-flight I/O.
  *
  * If the BIO has been marked as passthrough then the block device's
- * original MRF is used to process the BIO.  Otherwise, depending on
- * whether we're in snapshot or incremental mode, the appropriate handler
- * is called.
+ * original device's function pointer for handling i/o is used to process the BIO.
+ * Otherwise, depending on whether we're in snapshot or incremental mode, the appropriate 
+ * handler is called.
  *
  * Return: varies across versions of Linux and is what's expected by each for
  *         a make request function.
  */
-static MRF_RETURN_TYPE tracing_mrf(struct request_queue *q, struct bio *bio)
+static asmlinkage MRF_RETURN_TYPE tracing_fn(struct bio *bio)
+
+#else
+
+/**     
+ * tracing_fn() - This is the entry point for in-flight i/o we intercepted.
+ * @q: The &struct request_queue.
+ * @bio: The &struct bio which describes the I/O.
+ *
+ * If the BIO has been marked as passthrough then the block device's
+ * original device's function pointer for handling i/o is used to process the BIO.
+ * Otherwise, depending on whether we're in snapshot or incremental mode, the appropriate 
+ * handler is called.
+ *
+ * Return: varies across versions of Linux and is what's expected by each for
+ *         a make request function.
+ */
+static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
+
+#endif
 {
         int i, ret = 0;
-        struct snap_device *dev;
-        make_request_fn *orig_mrf = NULL;
-
+        struct snap_device *dev = NULL;
         MAYBE_UNUSED(ret);
 
         smp_rmb();
         tracer_for_each(dev, i)
         {
                 if (!dev || test_bit(UNVERIFIED, &dev->sd_state) ||
-                    !tracer_queue_matches_bio(dev, bio))
-                        continue;
+                        !tracer_queue_matches_bio(dev, bio))
+                                continue;
+                // If we get here, then we know this is a device we're managing
+                // and the current bio belongs to said device.
 
-                orig_mrf = dev->sd_orig_mrf;
-                if (dattobd_bio_op_flagged(bio, DATTOBD_PASSTHROUGH)) {
+                if (dattobd_bio_op_flagged(bio, DATTOBD_PASSTHROUGH))
+                {
                         dattobd_bio_op_clear_flag(bio, DATTOBD_PASSTHROUGH);
-                        goto call_orig;
                 }
-
-                if (tracer_should_trace_bio(dev, bio)) {
+                else if (tracer_should_trace_bio(dev, bio)) 
+                {
                         if (test_bit(SNAPSHOT, &dev->sd_state))
                                 ret = snap_trace_bio(dev, bio);
                         else
                                 ret = inc_trace_bio(dev, bio);
                         goto out;
                 }
-        }
-
-call_orig:
-        if (orig_mrf)
-                ret = dattobd_call_mrf(orig_mrf, q, bio);
-        else
-                LOG_ERROR(-EFAULT, "error finding original_mrf");
+                // Now we can submit the bio.
+                ret = SUBMIT_BIO_REAL(dev, bio);
+        } // tracer_for_each(dev, i)
 
 out:
+
         MRF_RETURN(ret);
 }
+
+#ifdef USE_BDOPS_SUBMIT_BIO
+
+/**
+ * dattobd_find_orig_gendisk() -  populates bd_disk and fn params with the original
+ * device's gendisk and submit_bio pointers (original device, meaning, not the one
+ * we messed with to re-route i/o to this kernel module).
+ *
+ * This function is the equivalent of dattobd_find_orig_mrf in <5.9 kernels. 
+ * In kernels >5.9 we use the gendisk->fops->submit_bio instead to hook our
+ * tracing_fn to intercept in-flight IO.
+ *
+ * Note: this should always set fn to some value, or else we didn't find a disk.
+ *
+ * @bdev: the 'real' block device.
+ * @bd_disk: Pointer to the gendisk to be set by this function. It will be set to
+ *           the gendisk contained in the bdev on success.
+ * @fn: Pointer to the submit_bio function pointer to be used to submit i/o to the
+ *      real device. This is either whichever function the kernel users, or 
+ *      dattobd_null_mrf on some kernels where submit_bio is normally null.
+ *
+ * Return:
+ * * 0  - success
+ * * -1 - if the gendisk/submit_bio ptr couldn't be extracted from the bdev.
+ */
+static int dattobd_find_orig_gendisk(
+    struct block_device *bdev,
+    struct gendisk **bd_disk,
+    submit_bio_fn **fn)
+{
+    struct gendisk *orig_ops = dattobd_get_gendisk(bdev);
+    submit_bio_fn *orig_fn = orig_ops->fops->submit_bio;
+    
+    if (!bdev) goto orig_gendisk_not_found;
+    
+    smp_wmb();
+    *bd_disk = orig_ops;
+    if (!orig_fn) 
+    {
+        *fn = dattobd_null_mrf;
+    }
+    else
+    {
+        *fn = orig_fn;
+    }
+    return 0;
+orig_gendisk_not_found:
+    *fn = NULL;
+    *bd_disk = NULL;
+    return -EINVAL;
+}
+
+#else // USE_BDOPS_SUBMIT_BIO
+
+/**
+ * dattobd_find_orig_mrf() - Locates the original MRF function associated with
+ *                   the @bdev block device.  All tracked block devices
+ *                   are checked until a match is found.
+ *
+ * @bdev: The &struct block_device that stores the COW data.
+ * @mrf: The original MRF function, if found.
+ *
+ * Return:
+ * * 0 - success
+ * * !0 - errno indicating the error
+ */
+static int dattobd_find_orig_mrf(struct block_device *bdev,
+                                 make_request_fn **mrf){
+        int i;
+        struct snap_device *dev;
+        struct request_queue *q = bdev_get_queue(bdev);
+        make_request_fn *orig_mrf = dattobd_get_bd_mrf(bdev);
+
+        if(orig_mrf != tracing_fn){
+#ifdef HAVE_BLK_MQ_MAKE_REQUEST
+                // Linux version 5.8
+                if (!orig_mrf){
+                        orig_mrf = dattobd_null_mrf;
+                        LOG_DEBUG(
+                            "original mrf is empty, set to dattobd_null_mrf");
+                }
+#endif
+            *mrf = orig_mrf;
+            return 0;
+        }
+
+        tracer_for_each(dev, i){
+                if(!dev || test_bit(UNVERIFIED, &dev->sd_state)) continue;
+                if(q == bdev_get_queue(dev->sd_base_dev)){
+                        *mrf = dev->sd_orig_request_fn;
+                        return 0;
+                }
+        }
+
+        *mrf = NULL;
+        return -EFAULT;
+}
+
+#endif // USE_BDOPS_SUBMIT_BIO
 
 /**
  * __tracer_should_reset_mrf() - Searches the traced devices and verifies that
@@ -1266,36 +1462,23 @@ out:
  */
 static int __tracer_should_reset_mrf(const struct snap_device *dev)
 {
-        struct snap_device *cur_dev;
-        struct request_queue *q = bdev_get_queue(dev->sd_base_dev);
+    int i;
+    struct snap_device *cur_dev;
+    struct request_queue *q = bdev_get_queue(dev->sd_base_dev);
 
-        // since kernel 5.8 make_request_fn can be null.
-        if (q->make_request_fn == NULL) {
-                LOG_ERROR(-EINVAL, "make_request_fn is null");
-                return -EINVAL;
+    if (GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev) != tracing_fn) return 0;
+    if (dev != snap_devices[dev->sd_minor]) return 0;
+
+    //return 0 if there is another device tracing the same queue as dev.
+    if (snap_devices){
+        tracer_for_each(cur_dev, i){
+            if (!cur_dev || test_bit(UNVERIFIED, &cur_dev->sd_state) 
+                || cur_dev == dev) continue;
+            if (q == bdev_get_queue(cur_dev->sd_base_dev)) return 0;
         }
+    }
 
-        if (q->make_request_fn != tracing_mrf)
-                return 0;
-        if (snap_devices) {
-                int i;
-                if (dev != snap_devices[dev->sd_minor])
-                        return 0;
-
-                // return 0 if there is another device tracing the same queue as
-                // dev.
-                tracer_for_each(cur_dev, i)
-                {
-                        if (!cur_dev ||
-                            test_bit(UNVERIFIED, &cur_dev->sd_state) ||
-                            cur_dev == dev)
-                                continue;
-                        if (q == bdev_get_queue(cur_dev->sd_base_dev))
-                                return 0;
-                }
-        }
-
-        return 1;
+    return 1;
 }
 
 /**
@@ -1307,23 +1490,49 @@ static int __tracer_should_reset_mrf(const struct snap_device *dev)
  */
 static void __tracer_destroy_tracing(struct snap_device *dev)
 {
-        if (dev->sd_orig_mrf) {
+        if(dev->sd_orig_request_fn){
                 LOG_DEBUG("replacing make_request_fn if needed");
-                if (__tracer_should_reset_mrf(dev))
+                if(__tracer_should_reset_mrf(dev)){
+#ifdef USE_BDOPS_SUBMIT_BIO
                         __tracer_transition_tracing(
-                                NULL, dev->sd_base_dev, dev->sd_orig_mrf,
-                                &snap_devices[dev->sd_minor]);
-                else
+                            NULL,
+                            dev->sd_base_dev,
+                            dev->sd_orig_gendisk,
+                            &snap_devices[dev->sd_minor]
+                        );
+#else
                         __tracer_transition_tracing(
-                                NULL, dev->sd_base_dev, NULL,
-                                &snap_devices[dev->sd_minor]);
+                            NULL,
+                            dev->sd_base_dev,
+                            dev->sd_orig_request_fn,
+                            &snap_devices[dev->sd_minor]
+                        );
+#endif
+                }
+        else
+        {
+                __tracer_transition_tracing(
+                        NULL,
+                        dev->sd_base_dev,
+                        NULL,
+                        &snap_devices[dev->sd_minor]
+                );
+        }
+        smp_wmb();
+        dattobd_free_request_tracking_ptr(dev);
 
-                dev->sd_orig_mrf = NULL;
-        } else if (snap_devices[dev->sd_minor] == dev) {
+        }
+        else if(snap_devices[dev->sd_minor] == dev)
+        {
                 smp_wmb();
                 snap_devices[dev->sd_minor] = NULL;
                 smp_wmb();
         }
+#ifdef USE_BDOPS_SUBMIT_BIO
+        if (dev->sd_orig_gendisk){
+                kfree(dev->sd_orig_gendisk);
+        }
+#endif
 
         dev->sd_minor = 0;
         minor_range_recalculate();
@@ -1340,68 +1549,18 @@ static void __tracer_destroy_tracing(struct snap_device *dev)
 static void __tracer_setup_tracing_unverified(struct snap_device *dev,
                                               unsigned int minor)
 {
-        dev->sd_orig_mrf = NULL;
-        minor_range_include(minor);
-        smp_wmb();
-        dev->sd_minor = minor;
-        snap_devices[minor] = dev;
-        smp_wmb();
-}
-
-/**
- * find_orig_mrf() - Locates the original MRF function associated with
- *                   the @bdev block device.  All tracked block devices
- *                   are checked until a match is found.
- *
- * @bdev: The &struct block_device that stores the COW data.
- * @mrf: The original MRF function, if found.
- *
- * Return:
- * * 0 - success
- * * !0 - errno indicating the error
- */
-static int find_orig_mrf(struct block_device *bdev, make_request_fn **mrf)
-{
-        int i;
-        struct snap_device *dev;
-        struct request_queue *q = bdev_get_queue(bdev);
-
-        // since kernel 5.8 make_request_fn can be null.
-        if (q->make_request_fn == NULL) {
-#ifndef HAVE_BLK_ALLOC_QUEUE
-                //#if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)
-                LOG_ERROR(-EINVAL, "make_request_fn is null");
-                return -EINVAL;
-#else
-                *mrf = dattobd_null_mrf;
-                return 0;
-#endif
-        }
-
-        if (q->make_request_fn != tracing_mrf) {
-                *mrf = q->make_request_fn;
-                return 0;
-        }
-
-        tracer_for_each(dev, i)
-        {
-                if (!dev || test_bit(UNVERIFIED, &dev->sd_state))
-                        continue;
-                if (q == bdev_get_queue(dev->sd_base_dev)) {
-                        *mrf = dev->sd_orig_mrf;
-                        return 0;
-                }
-        }
-
-        *mrf = NULL;
-        return -EFAULT;
+    minor_range_include(minor);
+    smp_wmb();
+    dev->sd_minor = minor;
+    snap_devices[minor] = dev;
+    smp_wmb();
 }
 
 /**
  * __tracer_setup_tracing() - Adds @minor to the range of included tracked
- *                            minors, saves the original MRF and installs
- *                            the tracing MRF for the block device associated
- *                            with our &struct snap_device.
+ *                            minors, saves the original io submit function ptr
+ *                            and replaces it with the tracing_fn function ptr for 
+ *                            the block device associated with our &struct snap_device.
  *
  * @dev: The &struct snap_device object pointer.
  * @minor: the device's minor number.
@@ -1412,28 +1571,48 @@ static int find_orig_mrf(struct block_device *bdev, make_request_fn **mrf)
  */
 int __tracer_setup_tracing(struct snap_device *dev, unsigned int minor)
 {
-        int ret;
+        int ret = 0;
 
         dev->sd_minor = minor;
         minor_range_include(minor);
 
         // get the base block device's make_request_fn
         LOG_DEBUG("getting the base block device's make_request_fn");
-        ret = find_orig_mrf(dev->sd_base_dev, &dev->sd_orig_mrf);
+#ifdef USE_BDOPS_SUBMIT_BIO
+        if (!dev->sd_orig_gendisk){
+                // new snapshot (not incremental)
+                ret = dattobd_find_orig_gendisk(
+                        dev->sd_base_dev,
+                        &dev->sd_orig_gendisk,
+                        &dev->sd_orig_request_fn);
+                dev->sd_orig_fops = (struct block_device_operations*)
+                                    dev->sd_orig_gendisk->fops;
+                dev->sd_tracing_gendisk = dattobd_copy_gendisk(
+                        dev->sd_orig_gendisk, tracing_fn);
+        }
+        ret = __tracer_transition_tracing(
+                dev, 
+                dev->sd_base_dev,
+                dev->sd_tracing_gendisk,
+                &snap_devices[minor]);
+#else
+        ret = dattobd_find_orig_mrf(dev->sd_base_dev, &dev->sd_orig_request_fn);
         if (ret)
                 goto error;
-
-        ret = __tracer_transition_tracing(dev, dev->sd_base_dev, tracing_mrf,
-                                          &snap_devices[minor]);
+        ret = __tracer_transition_tracing(
+                dev,
+                dev->sd_base_dev,
+                tracing_fn,
+                &snap_devices[minor]);
+#endif
         if (ret)
                 goto error;
-
         return 0;
 
 error:
         LOG_ERROR(ret, "error setting up tracing");
         dev->sd_minor = 0;
-        dev->sd_orig_mrf = NULL;
+        dev->sd_orig_request_fn = NULL;
         minor_range_recalculate();
         return ret;
 }
@@ -1573,6 +1752,8 @@ error:
         return ret;
 }
 
+/************************IOCTL TRANSITION FUNCTIONS************************/
+
 /**
  * tracer_active_snap_to_inc() - Transitions from snapshot mode to incremental
  * tracking.
@@ -1611,8 +1792,11 @@ int tracer_active_snap_to_inc(struct snap_device *old_dev)
         if (ret)
                 goto error;
 
-        // inject the tracing function and write the new dev into
-        // the snap_devices array.
+        // inject the tracing function
+#ifdef USE_BDOPS_SUBMIT_BIO
+        dev->sd_orig_gendisk = old_dev->sd_orig_gendisk;
+#endif
+        dev->sd_orig_request_fn = old_dev->sd_orig_request_fn;
         ret = __tracer_setup_tracing(dev, old_dev->sd_minor);
         if (ret)
                 goto error;
@@ -1740,6 +1924,10 @@ int tracer_active_inc_to_snap(struct snap_device *old_dev, const char *cow_path,
                 goto error;
 
         // start tracing (overwrites old_dev's tracing)
+#ifdef USE_BDOPS_SUBMIT_BIO
+        dev->sd_orig_gendisk = old_dev->sd_orig_gendisk;
+#endif
+        dev->sd_orig_request_fn = old_dev->sd_orig_request_fn;
         ret = __tracer_setup_tracing(dev, old_dev->sd_minor);
         if (ret)
                 goto error;
@@ -1812,6 +2000,8 @@ void tracer_dattobd_info(const struct snap_device *dev,
                 memset(info->uuid, 0, COW_UUID_SIZE);
         }
 }
+
+/************************AUTOMATIC TRANSITION FUNCTIONS************************/
 
 /**
  * __tracer_active_to_dormant() - Transitions from ACTIVE to DORMANT.  This

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1594,6 +1594,7 @@ int __tracer_setup_tracing(struct snap_device *dev, unsigned int minor)
                 dev->sd_orig_fops = (struct block_device_operations*)
                                     dev->sd_orig_gendisk->fops;
                 dev->sd_tracing_gendisk = dattobd_copy_gendisk(
+                        dev->sd_base_dev,
                         dev->sd_orig_gendisk, tracing_fn);
         }
         ret = __tracer_transition_tracing(

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -8,6 +8,7 @@
 
 #include "bio_request_callback.h"
 #include "blkdev.h"
+#include "callback_refs.h"
 #include "cow_manager.h"
 #include "filesystem.h"
 #include "hints.h"
@@ -1193,7 +1194,7 @@ error:
 static int __tracer_transition_tracing(
     struct snap_device *dev,
     struct block_device *bdev,
-    BIO_REQUEST_TRACKING_PTR_TYPE *new_bio_tracking_ptr,
+    const BIO_REQUEST_TRACKING_PTR_TYPE *new_bio_tracking_ptr,
     struct snap_device **dev_ptr)
 {
         int ret;
@@ -1243,6 +1244,7 @@ static int __tracer_transition_tracing(
                 LOG_DEBUG("starting tracing");
                 *dev_ptr = dev;
                 smp_wmb();
+                ret = gendisk_fn_get(bdev, new_bio_tracking_ptr);
                 if(new_bio_tracking_ptr){
 #ifdef USE_BDOPS_SUBMIT_BIO            
                         dattobd_set_gendisk(bdev, new_bio_tracking_ptr);
@@ -1253,6 +1255,7 @@ static int __tracer_transition_tracing(
                 }
         }else{
                 LOG_DEBUG("ending tracing");
+                new_bio_tracking_ptr = gendisk_fn_put(bdev);
                 if (new_bio_tracking_ptr){
 #ifdef USE_BDOPS_SUBMIT_BIO
                         dattobd_set_gendisk(bdev, new_bio_tracking_ptr);
@@ -1325,26 +1328,28 @@ static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
         smp_rmb();
         tracer_for_each(dev, i)
         {
-                if (!dev || test_bit(UNVERIFIED, &dev->sd_state) ||
-                        !tracer_queue_matches_bio(dev, bio))
-                                continue;
+                if (!tracer_is_bio_for_dev(dev, bio)) continue;
                 // If we get here, then we know this is a device we're managing
                 // and the current bio belongs to said device.
-
                 if (dattobd_bio_op_flagged(bio, DATTOBD_PASSTHROUGH))
                 {
                         dattobd_bio_op_clear_flag(bio, DATTOBD_PASSTHROUGH);
                 }
-                else if (tracer_should_trace_bio(dev, bio)) 
+                else
                 {
-                        if (test_bit(SNAPSHOT, &dev->sd_state))
-                                ret = snap_trace_bio(dev, bio);
-                        else
-                                ret = inc_trace_bio(dev, bio);
-                        goto out;
+                        if (tracer_should_trace_bio(dev, bio))
+                        {
+                                if (test_bit(SNAPSHOT, &dev->sd_state))
+                                        ret = snap_trace_bio(dev, bio);
+                                else
+                                        ret = inc_trace_bio(dev, bio);
+                                goto out;
+                        }
                 }
                 // Now we can submit the bio.
                 ret = SUBMIT_BIO_REAL(dev, bio);
+                goto out;
+                
         } // tracer_for_each(dev, i)
 
 out:
@@ -1578,6 +1583,7 @@ int __tracer_setup_tracing(struct snap_device *dev, unsigned int minor)
 
         // get the base block device's make_request_fn
         LOG_DEBUG("getting the base block device's make_request_fn");
+
 #ifdef USE_BDOPS_SUBMIT_BIO
         if (!dev->sd_orig_gendisk){
                 // new snapshot (not incremental)

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -14,6 +14,9 @@ struct dattobd_info;
 struct snap_device;
 struct bio;
 
+//maximum number of clones per traced bio
+#define MAX_CLONES_PER_BIO 10
+
 #define tracer_setup_unverified_inc(dev, minor, bdev_path, cow_path,           \
                                     cache_size)                                \
         __tracer_setup_unverified(dev, minor, bdev_path, cow_path, cache_size, \
@@ -36,6 +39,7 @@ int tracer_setup_active_snap(struct snap_device *dev, unsigned int minor,
 int __tracer_setup_unverified(struct snap_device *dev, unsigned int minor,
                               const char *bdev_path, const char *cow_path,
                               unsigned long cache_size, int is_snap);
+void dattobd_free_request_tracking_ptr(struct snap_device *dev);
 
 /************************IOCTL TRANSITION FUNCTIONS************************/
 

--- a/src/tracer_helper.c
+++ b/src/tracer_helper.c
@@ -27,14 +27,14 @@ void tracer_set_fail_state(struct snap_device *dev, int error)
 
 bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio)
 {
-    return dev && tracer_sector_matches_bio(dev, bio);
+    return dev && tracer_sector_matches_bio(dev, bio) 
+                && tracer_queue_matches_bio(dev, bio);
 }
 
 bool tracer_should_trace_bio(struct snap_device *dev, struct bio *bio)
 {
     return dev 
             && !test_bit(UNVERIFIED, &dev->sd_state)
-            && tracer_queue_matches_bio(dev, bio)
             && !bio_is_discard(bio)
             && bio_data_dir(bio)
             && bio_size(bio) 

--- a/src/tracer_helper.c
+++ b/src/tracer_helper.c
@@ -4,31 +4,39 @@
  * Copyright (C) 2022 Datto Inc.
  */
 
+#include "tracer_helper.h"
+
+#include "bio_helper.h"
 #include "includes.h"
 #include "snap_device.h"
 
-/**
- * tracer_read_fail_state() - Returns the error code currently set for the
- *                            &struct snap_device.
- * @dev: The &struct snap_device object pointer.
- *
- * Return: the error code, zero indicates no error set.
- */
+
 int tracer_read_fail_state(const struct snap_device *dev)
 {
         smp_mb();
         return atomic_read(&dev->sd_fail_code);
 }
 
-/**
- * tracer_set_fail_state() - Sets an error code for the &struct snap_device.
- *
- * @dev: The &struct snap_device object pointer.
- * @error: The error to set.
- */
+
 void tracer_set_fail_state(struct snap_device *dev, int error)
 {
         smp_mb();
         (void)atomic_cmpxchg(&dev->sd_fail_code, 0, error);
         smp_mb();
+}
+
+bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio)
+{
+    return dev && tracer_sector_matches_bio(dev, bio);
+}
+
+bool tracer_should_trace_bio(struct snap_device *dev, struct bio *bio)
+{
+    return dev 
+            && !test_bit(UNVERIFIED, &dev->sd_state)
+            && tracer_queue_matches_bio(dev, bio)
+            && !bio_is_discard(bio)
+            && bio_data_dir(bio)
+            && bio_size(bio) 
+            && !tracer_read_fail_state(dev);
 }

--- a/src/tracer_helper.h
+++ b/src/tracer_helper.h
@@ -32,16 +32,47 @@
         (bio_sector(bio) >= (dev)->sd_sect_off &&                              \
          bio_sector(bio) < (dev)->sd_sect_off + (dev)->sd_size)
 
-// should be called along with *_queue_matches_bio to be valid. returns true if
-// bio is a write, has a size, tracing struct is in non-fail state, and the
-// device's sector range matches the bio
-#define tracer_should_trace_bio(dev, bio)                                      \
-        (bio_data_dir(bio) && !bio_is_discard(bio) && bio_size(bio) &&         \
-         !tracer_read_fail_state(dev) && tracer_sector_matches_bio(dev, bio))
+/**
+ * tracer_is_bio_for_dev() - Check if bio is intended for given snap_device.
+ *
+ * returns true if bio's queue matches the devices' queue and partition, and if
+ * bio has a size, tracing struct is in non-fail state, and the
+ * device's sector range matches the bio.
+ *
+ * @dev: The snap_device to check the bio against.
+ * @bio: The bio to check the snap device against.
+ *
+ * Return: True if bio is for dev (+ conditions described above). 
+ *         False otherwise.
+ */
+bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio);
+
+/**
+ * tracer_should_trace_bio() - Check if given bio should be traced.
+ *
+ * Return: Returns true if dev is not null
+ *         and if bio has a size, is a write, and it's tracing struct is in a
+ *         non-fail state, and the device's sector range matches the bio.
+ */
+bool tracer_should_trace_bio(struct snap_device *dev, struct bio *bio);
 
 struct snap_device;
 
+/**
+ * tracer_read_fail_state() - Returns the error code currently set for the
+ *                            &struct snap_device.
+ * @dev: The &struct snap_device object pointer.
+ *
+ * Return: the error code, zero indicates no error set.
+ */
 int tracer_read_fail_state(const struct snap_device *dev);
+
+/**
+ * tracer_set_fail_state() - Sets an error code for the &struct snap_device.
+ *
+ * @dev: The &struct snap_device object pointer.
+ * @error: The error to set.
+ */
 void tracer_set_fail_state(struct snap_device *dev, int error);
 
 #endif /* TRACER_HELPER_H_ */


### PR DESCRIPTION
Add support for submit_bio tracing in addition to make_request_fn in order to make kernels >= 5.9 work.
This is done by keeping track of a tracing and 'real' gendisk in order to avoid a symbol lookup for blk_md_submit_bio 