### PR TITLE
Fix out of array's bound in cow_read_mapping

### DIFF
--- a/src/snap_handle.c
+++ b/src/snap_handle.c
@@ -56,7 +56,7 @@ static int snap_read_bio_get_mode(const struct snap_device *dev,
                         curr_byte = curr_end_byte;
                         curr_end_byte += min(
                                 COW_BLOCK_SIZE - (curr_byte % COW_BLOCK_SIZE),
-                                ((uint64_t)bio_iter_len(bio, iter)));
+                                ((uint64_t)bio_iter_len(bio, iter) - bytes));
 
                         // check if the mapping exists
                         ret = cow_read_mapping(dev->sd_cow,


### PR DESCRIPTION
In function snap_read_bio_get_mode, curr_end_bytes is uncorrect in second cycle of while loop, it shound minus the bytes have read in first cycle. This bug will cause out of array's bound in cow_read_mapping, finally kernel crashed.

details: https://github.com/datto/dattobd/issues/286

this patch tested in a 5TB xfs volume of centos 7.6.1810