### PR TITLE
Add OBS workflows definition for package builds

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,0 +1,29 @@
+rebuild_workflow:
+  steps:
+    - trigger_services:
+        project: isv:Datto:LinuxAgent:DattoBD:Mainline
+        package: dattobd-git
+  filters:
+    event: push
+    branches:
+      only:
+        - main
+main_workflow:
+  steps:
+    - branch_package:
+        source_project: isv:Datto:LinuxAgent:DattoBD:Mainline
+        source_package: dattobd-git
+        target_project: isv:Datto:LinuxAgent:DattoBD:CI
+  filters:
+    event: pull_request
+    branches:
+      only:
+        - main
+release_workflow:
+  steps:
+    - branch_package:
+        source_project: isv:Datto:LinuxAgent:DattoBD:Mainline
+        source_package: dattobd
+        target_project: isv:Datto:LinuxAgent:DattoBD
+  filters:
+    event: tag_push

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,9 @@
 # dattobd INSTALL
 
-## From Repositories
+## From the openSUSE Build Service
+We offer [the latest mainline code from the openSUSE Build Service for a number of Linux distributions](https://software.opensuse.org//download.html?project=isv%3ADatto%3ALinuxAgent%3ADattoBD%3AMainline&package=dattobd).
+
+## From Datto Repositories
 We recommend that you install the kernel module from Datto's repositories. Datto provides repos for x86-64 editions of RHEL/CentOS, Fedora, openSUSE, SUSE Linux Enterprise, Debian, and Ubuntu LTS.
 
 ### RHEL/CentOS


### PR DESCRIPTION
This enables the openSUSE Build Service SCM CI workflow system so that packages can be built in the openSUSE Build Service.

This also adds a small amount of documentation to access the latest snapshot code packaged up there.