### PR TITLE
dattobd works properly on rhel9.1

### DIFF
--- a/src/configure-tests/feature-tests/genhd_fl_no_part.c
+++ b/src/configure-tests/feature-tests/genhd_fl_no_part.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2015 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct gendisk gd;
+	gd.flags = GENHD_FL_NO_PART;
+}

--- a/src/configure-tests/feature-tests/genhd_fl_no_part.c
+++ b/src/configure-tests/feature-tests/genhd_fl_no_part.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2015 Datto Inc.
+ * Copyright (C) 2023 Datto Inc.
  */
 
 #include "includes.h"

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1108,6 +1108,10 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor,
         //  disable partition scanning (the device should not have any
         //  sub-partitions)
         dev->sd_gd->flags |= GENHD_FL_NO_PART_SCAN;
+#elif defined  HAVE_GENHD_FL_NO_PART  
+        // with removal of genhd.h header file name of kernel's constant 
+        // was changed from GENHD_FL_NO_PART_SCAN to GENHD_FL_NO_PART
+        dev->sd_gd->flags |= GENHD_FL_NO_PART;
 #endif
 
         // set the device as read-only


### PR DESCRIPTION
- works properly on rhel9.1 (https://jira.datto.net/secure/Tests.jspa#/testCase/KD-T1 steps checked)
- builds on Ubuntu18
- other releases in progress
