### PR TITLE
Fix unavailability to free memory in cache

### DIFF
--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -149,6 +149,7 @@ int __cow_write_section(struct cow_manager *cm, unsigned long sect_idx)
 static int __cow_sync_and_free_sections(struct cow_manager *cm,
                                         unsigned long thresh)
 {
+        LOG_DEBUG("__cow_sync_and_free_sections");
         int ret;
         unsigned long i;
 

--- a/src/module_control.c
+++ b/src/module_control.c
@@ -42,7 +42,7 @@ int dattobd_may_hook_syscalls = 1;
 unsigned long dattobd_cow_max_memory_default = (300 * 1024 * 1024);
 unsigned int dattobd_cow_fallocate_percentage_default = 10;
 unsigned int dattobd_max_snap_devices = DATTOBD_DEFAULT_SNAP_DEVICES;
-int dattobd_debug = 0;
+int dattobd_debug = 1;
 
 module_param_named(may_hook_syscalls, dattobd_may_hook_syscalls, int, S_IRUGO);
 MODULE_PARM_DESC(may_hook_syscalls,

--- a/src/module_threads.c
+++ b/src/module_threads.c
@@ -119,11 +119,13 @@ int snap_cow_thread(void *data)
                                 cow_free_members(dev->sd_cow);
                 }
 
+#ifdef USE_BDOPS_SUBMIT_BIO
                 int should_stop=kthread_should_stop();
                 if(should_stop){
-                        LOG_DEBUG("stopping snap thread in if");
+                        LOG_DEBUG("stopping snap thread in conditional");
                         break;
                 }
+#endif
 
                 if (bio_queue_empty(bq))
                         continue;

--- a/src/module_threads.c
+++ b/src/module_threads.c
@@ -119,7 +119,7 @@ int snap_cow_thread(void *data)
                                 cow_free_members(dev->sd_cow);
                 }
 
-#if defined USE_BDOPS_SUBMIT_BIO && defined HAVE_BIO_BI_REMAINING
+#if defined USE_BDOPS_SUBMIT_BIO && defined HAVE_FOPS_FALLOCATE
 //not having it for .deb causes infinite loop and failure, having this for rpms causes objdump caused by not being able to save cached data during unmounting
                 int should_stop=kthread_should_stop();
                 if(should_stop){

--- a/src/module_threads.c
+++ b/src/module_threads.c
@@ -172,7 +172,6 @@ int snap_cow_thread(void *data)
                 }
         }
         LOG_DEBUG("snap_cow_thread has stopped");
-
         return 0;
 }
 

--- a/src/module_threads.c
+++ b/src/module_threads.c
@@ -119,7 +119,8 @@ int snap_cow_thread(void *data)
                                 cow_free_members(dev->sd_cow);
                 }
 
-#ifdef USE_BDOPS_SUBMIT_BIO
+#if defined USE_BDOPS_SUBMIT_BIO && defined HAVE_BIO_BI_REMAINING
+//not having it for .deb causes infinite loop and failure, having this for rpms causes objdump caused by not being able to save cached data during unmounting
                 int should_stop=kthread_should_stop();
                 if(should_stop){
                         LOG_DEBUG("stopping snap thread in conditional");

--- a/src/module_threads.c
+++ b/src/module_threads.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2022 Datto Inc.
+ * Copyright (C) 2024 Datto Inc.
  */
 
 #include "module_threads.h"

--- a/src/module_threads.c
+++ b/src/module_threads.c
@@ -80,6 +80,7 @@ int inc_sset_thread(void *data)
                 // free the sector set
                 kfree(sset);
         }
+        LOG_DEBUG("inc_sset_thread has stopped");
 
         return 0;
 }
@@ -170,6 +171,7 @@ int snap_cow_thread(void *data)
                         bio_free_clone(bio);
                 }
         }
+        LOG_DEBUG("snap_cow_thread has stopped");
 
         return 0;
 }

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1379,8 +1379,7 @@ static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
                 if (dattobd_bio_op_flagged(bio, DATTOBD_PASSTHROUGH))
                 {
                         dattobd_bio_op_clear_flag(bio, DATTOBD_PASSTHROUGH);
-                        static int counter=0;
-                        LOG_DEBUG("suspected place #1 %d",++counter);
+                        goto call_orig;
                 }
                 else
                 {
@@ -1399,6 +1398,7 @@ static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
 #endif
         } // tracer_for_each(dev, i)
 
+call_orig:
 #ifdef USE_BDOPS_SUBMIT_BIO
         if(orig_fn){
                 orig_fn(bio);

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -158,6 +158,7 @@ void dattobd_free_request_tracking_ptr(struct snap_device *dev)
                 tracing_ops_put(dev->sd_tracing_ops);
                 dev->sd_tracing_ops=NULL;
         }
+        dev->sd_tracing_ops=NULL;
 #else
         dev->sd_orig_request_fn = NULL;
 #endif
@@ -1378,6 +1379,8 @@ static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
                 if (dattobd_bio_op_flagged(bio, DATTOBD_PASSTHROUGH))
                 {
                         dattobd_bio_op_clear_flag(bio, DATTOBD_PASSTHROUGH);
+                        static int counter=0;
+                        LOG_DEBUG("suspected place #1 %d",++counter);
                 }
                 else
                 {

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -924,6 +924,7 @@ static void __tracer_bioset_exit(struct snap_device *dev)
                 dev->sd_bioset = NULL;
         }
 #else
+        LOG_DEBUG("freeing bio set");
         bioset_exit(&dev->sd_bioset);
 #endif
 }

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1283,6 +1283,7 @@ static int __tracer_transition_tracing(
                         bdev_name);
 #endif
         }
+        LOG_DEBUG("stopped freezing, smb");
         smp_wmb();
         if(dev){
                 LOG_DEBUG("starting tracing");


### PR DESCRIPTION
Some day there should be made further investigation in this topic, for .deb we are not able to close this ifdef what causes that we are not able to return control to ioctl, for rpms it looks like it block us from freeing cache.
- USE_BDOPS_SUBMIT_BIO (kernels with submit_bio based writing >= 5.9)
- HAVE_FOPS_FALLOCATE- present: ubuntu 20, 22 not present: centos 8 and rhel 9
