### PR TITLE
fix build failed in old ubuntu

### DIFF
--- a/src/bio_helper.c
+++ b/src/bio_helper.c
@@ -124,7 +124,7 @@ void dattobd_set_bio_ops(struct bio *bio, req_op_t op, unsigned op_flags)
 }
 #endif
 
-#ifndef HAVE_BIO_BI_OPF 
+#if !defined(HAVE_BIO_BI_OPF) && defined(HAVE_ENUM_REQ_OP)
 void dattobd_set_bio_ops(struct bio *bio, req_op_t op, unsigned op_flags)
 {
        bio->bi_rw = 0;

--- a/src/configure-tests/feature-tests/blk_alloc_queue_1.c
+++ b/src/configure-tests/feature-tests/blk_alloc_queue_1.c
@@ -10,4 +10,5 @@ MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
     struct request_queue *rq = blk_alloc_queue(GFP_KERNEL);
+    (void)rq;
 }


### PR DESCRIPTION
If (void)rq is not added during compilation, an unused warning will appear. However, in the src/configure-tests/feature-tests/Makefile, the Werror flag is included, causing the feature not to be tested. Consequently, this leads to the module using unexpected parameters for blk_alloc_queue.

Currently, the issue is observed in older kernel versions, such as Fedora 30 (5.6.13-100.fc30.x86_64) and Ubuntu 16 (4.4.0-186-generic).