### PR TITLE
initialize snap device for cow

### DIFF
--- a/src/bdev_state_handler.c
+++ b/src/bdev_state_handler.c
@@ -189,12 +189,15 @@ int handle_bdev_mount_event(const char *dir_name, int follow_flags,
         if (!(follow_flags & UMOUNT_NOFOLLOW))
                 lookup_flags |= LOOKUP_FOLLOW;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,5,0)
+#ifdef HAVE_KERN_PATH
         ret = kern_path(dir_name, lookup_flags, &path);
 #else
         ret = user_path_at(AT_FDCWD, dir_name, lookup_flags, &path);
-#endif //LINUX_VERSION_CODE
-
+#endif //HAVE_KERN_PATH
+        if (ret) {
+                LOG_DEBUG("error finding path");
+                goto out;
+        }
         LOG_DEBUG("path->dentry: %s, path->mnt->mnt_root: %s", path.dentry->d_name.name, path.mnt->mnt_root->d_name.name);
 
         if (path.dentry != path.mnt->mnt_root) {

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -642,6 +642,7 @@ error:
  * cow_init() - Allocates a &struct cow_manager object and initializes it.
  *              Also creates the COW backing file on disk and writes a
  *              header into it.
+ * @dev:  The &struct snap_device that keeps snapshot device state.
  * @path: The path to the COW file.
  * @elements: typically the number of sectors on the block device.
  * @sect_size: The basic unit of size that the &struct cow_manager works with.
@@ -656,7 +657,7 @@ error:
  * * 0 - success
  * * !0 - errno indicating the error
  */
-int cow_init(const char *path, uint64_t elements, unsigned long sect_size,
+int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsigned long sect_size,
              unsigned long cache_size, uint64_t file_max, const uint8_t *uuid,
              uint64_t seqid, struct cow_manager **cm_out)
 {
@@ -691,7 +692,7 @@ int cow_init(const char *path, uint64_t elements, unsigned long sect_size,
                 __cow_calculate_allowed_sects(cache_size, cm->total_sects);
         cm->data_offset = COW_HEADER_SIZE + (cm->total_sects * (sect_size * 8));
         cm->curr_pos = cm->data_offset / COW_BLOCK_SIZE;
-
+        cm->dev = dev;
         if (uuid)
                 memcpy(cm->uuid, uuid, COW_UUID_SIZE);
         else

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -81,7 +81,7 @@ int cow_reload(const char *path, uint64_t elements, unsigned long sect_size,
                unsigned long cache_size, int index_only,
                struct cow_manager **cm_out);
 
-int cow_init(const char *path, uint64_t elements, unsigned long sect_size,
+int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsigned long sect_size,
              unsigned long cache_size, uint64_t file_max, const uint8_t *uuid,
              uint64_t seqid, struct cow_manager **cm_out);
 

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -646,7 +646,7 @@ static int __tracer_setup_cow(struct snap_device *dev,
 
                         // create and open the cow manager
                         LOG_DEBUG("creating cow manager");
-                        ret = cow_init(cow_path, SECTOR_TO_BLOCK(size),
+                        ret = cow_init(dev, cow_path, SECTOR_TO_BLOCK(size),
                                        COW_SECTION_SIZE, dev->sd_cache_size,
                                        max_file_size, uuid, seqid,
                                        &dev->sd_cow);

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -860,7 +860,8 @@ static void __tracer_copy_cow(const struct snap_device *src,
         // copy cow file extents and update the device
 	dest->sd_cow_extents = src->sd_cow_extents;
 	dest->sd_cow_ext_cnt = src->sd_cow_ext_cnt;
-
+        dest->sd_cow->dev = dest;
+        
         dest->sd_cow_inode = src->sd_cow_inode;
         dest->sd_cache_size = src->sd_cache_size;
         dest->sd_falloc_size = src->sd_falloc_size;


### PR DESCRIPTION
Hi, this is the complete work covering crash during reboot (handle_bdev_mount_event during transition from active to dormant state). This solution provides proper handling of cow_file_extens. It should solve #365