### PR TITLE
RHEL 8.9 nullptr dereference

### DIFF
--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -473,7 +473,7 @@ fi
 if [ ! -d %{_systemd_services}/reboot.target.wants/ ]; then
    mkdir -p %{_systemd_services}/reboot.target.wants
 fi   
-ln -s %{_systemd_services}/umount-rootfs.service   %{_systemd_services}/reboot.target.wants/umount-rootfs.service 
+ln -fs %{_systemd_services}/umount-rootfs.service   %{_systemd_services}/reboot.target.wants/umount-rootfs.service 
 
 %postun -n %{libname}
 /sbin/ldconfig
@@ -517,7 +517,7 @@ rm -rf %{buildroot}
 
 
 %post 
-ln -s %{_systemd_services}/umount-rootfs.service   %{_systemd_services}/reboot.target.wants/umount-rootfs.service 
+ln -fs %{_systemd_services}/umount-rootfs.service   %{_systemd_services}/reboot.target.wants/umount-rootfs.service 
 
 %doc README.md doc/STRUCTURE.md
 %if "%{_vendor}" == "redhat"

--- a/src/bdev_state_handler.c
+++ b/src/bdev_state_handler.c
@@ -122,7 +122,7 @@ int __handle_bdev_mount_writable(const char *dir_name,
                 if (test_bit(UNVERIFIED, &dev->sd_state)) {
                         // get the block device for the unverified tracer we are
                         // looking into
-                        cur_bdev = blkdev_get_by_path(dev->sd_bdev_path,
+                        cur_bdev = dattodb_blkdev_by_path(dev->sd_bdev_path,
                                                       FMODE_READ, NULL);
                         if (IS_ERR(cur_bdev)) {
                                 cur_bdev = NULL;
@@ -257,7 +257,7 @@ void post_umount_check(int dormant_ret, int umount_ret, unsigned int idx,
         // reactivate
         if (umount_ret) {
                 struct block_device *bdev;
-                bdev = blkdev_get_by_path(dev->sd_bdev_path, FMODE_READ, NULL);
+                bdev = dattodb_blkdev_by_path(dev->sd_bdev_path, FMODE_READ, NULL);
                 if (!bdev || IS_ERR(bdev)) {
                         LOG_DEBUG("device gone, moving to error state");
                         tracer_set_fail_state(dev, -ENODEV);

--- a/src/bdev_state_handler.c
+++ b/src/bdev_state_handler.c
@@ -28,7 +28,7 @@ void auto_transition_active(unsigned int minor, const char *dir_name)
 {
         struct snap_device *dev = snap_devices[minor];
 
-LOG_DEBUG("ENTER %s minor: %d", __func__, minor);
+        LOG_DEBUG("ENTER %s minor: %d", __func__, minor);
         mutex_lock(&ioctl_mutex);
 
         if (test_bit(UNVERIFIED, &dev->sd_state)) {
@@ -107,8 +107,7 @@ int __handle_bdev_mount_writable(const char *dir_name,
         struct snap_device *dev;
         struct block_device *cur_bdev;
 
-        LOG_DEBUG("ENTER __handle_bdev_mount_writable");
-
+        LOG_DEBUG("ENTER %s", __func__);
         tracer_for_each(dev, i)
         {
                 if (!dev || test_bit(ACTIVE, &dev->sd_state) ||
@@ -159,7 +158,7 @@ int __handle_bdev_mount_writable(const char *dir_name,
         ret = -ENODEV;
 
 out:
-        LOG_DEBUG("EXIT __handle_bdev_mount_writable");
+        LOG_DEBUG("EXIT %s", __func__);
         *idx_out = i;
         return ret;
 }
@@ -194,6 +193,10 @@ int handle_bdev_mount_event(const char *dir_name, int follow_flags,
 #else
         ret = user_path_at(AT_FDCWD, dir_name, lookup_flags, &path);
 #endif //LINUX_VERSION_CODE
+        if (ret) {
+                LOG_DEBUG("error finding path");
+                goto out;
+        }
 
         LOG_DEBUG("path->dentry: %s, path->mnt->mnt_root: %s", path.dentry->d_name.name, path.mnt->mnt_root->d_name.name);
 
@@ -245,10 +248,10 @@ void post_umount_check(int dormant_ret, int umount_ret, unsigned int idx,
         struct snap_device *dev;
         struct super_block *sb;
 
-        //LOG_DEBUG("ENTER %s", __func__);
+        LOG_DEBUG("ENTER %s", __func__);
         // if we didn't do anything or failed, just return
-        if (dormant_ret){
-                //LOG_DEBUG("dormant_ret");
+        if (dormant_ret) {
+                LOG_DEBUG("EXIT %s, dormant_ret", __func__);
                 return;
         }
         dev = snap_devices[idx];

--- a/src/bio_helper.c
+++ b/src/bio_helper.c
@@ -124,7 +124,7 @@ void dattobd_set_bio_ops(struct bio *bio, req_op_t op, unsigned op_flags)
 }
 #endif
 
-#ifndef HAVE_BIO_BI_OPF 
+#if !defined(HAVE_BIO_BI_OPF) && defined(HAVE_ENUM_REQ_OP)
 void dattobd_set_bio_ops(struct bio *bio, req_op_t op, unsigned op_flags)
 {
        bio->bi_rw = 0;

--- a/src/blkdev.c
+++ b/src/blkdev.c
@@ -80,11 +80,7 @@ static struct block_device *_blkdev_get_by_path(const char *pathname, fmode_t mo
                 return bdev;
 
         if ((mode & FMODE_WRITE) && bdev_read_only(bdev)) {
-#ifdef HAVE_BLKDEV_PUT_1
-                blkdev_put(bdev);
-#else
-                blkdev_put(bdev, mode);
-#endif
+                dattobd_blkdev_put(bdev);
                 return ERR_PTR(-EACCES);
         }
 
@@ -164,5 +160,28 @@ void dattobd_drop_super(struct super_block *sb)
 
 #else
         return;
+#endif
+}
+
+/**
+ * dattobd_blkdev_put() - Releases a reference to a block device.
+ * This function performs the appropriate action based on the available
+ * kernel functions to release or drop the superblock.
+ *
+ * @bd: block device structure pointer to be released.
+ *
+ * Return:
+ * void.
+ */
+void dattobd_blkdev_put(struct block_device *bd) 
+{
+#if defined HAVE_BLKDEV_PUT_1
+        return blkdev_put(bd);
+
+#elif defined HAVE_BLKDEV_PUT_2
+        return blkdev_put(bd,NULL);
+
+#else
+        return blkdev_put(bd, FMODE_READ);
 #endif
 }

--- a/src/blkdev.c
+++ b/src/blkdev.c
@@ -6,7 +6,7 @@
 
 #include "blkdev.h"
 
-#ifndef HAVE_BLKDEV_GET_BY_PATH
+#if !defined HAVE_BLKDEV_GET_BY_PATH && !defined HAVE_BLKDEV_GET_BY_PATH_4
 
 /**
  * dattobd_lookup_bdev() - Looks up the inode associated with the path, verifies
@@ -58,13 +58,8 @@ fail:
         goto out;
 }
 
-#endif
-
-#ifndef HAVE_BLKDEV_GET_BY_PATH
-//#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
-
 /**
- * blkdev_get_by_path() - Fetches the @block_device struct associated with the
+ * _blkdev_get_by_path() - Fetches the @block_device struct associated with the
  * @pathname.  This is very similar to @dattobd_lookup_bdev with minor
  * additional validation.
  *
@@ -76,7 +71,7 @@ fail:
  * On success the @block_device structure otherwise an error created via
  * ERR_PTR().
  */
-struct block_device *blkdev_get_by_path(const char *pathname, fmode_t mode,
+static struct block_device *_blkdev_get_by_path(const char *pathname, fmode_t mode,
                                         void *holder)
 {
         struct block_device *bdev;
@@ -97,3 +92,30 @@ struct block_device *blkdev_get_by_path(const char *pathname, fmode_t mode,
 }
 
 #endif
+
+/**
+ * dattodb_blkdev_by_path() - Fetches the @block_device struct associated with the
+ * @path. This function uses different methods based on available kernel functions
+ * to retrieve the block device.
+ *
+ * @path: the path name of a block special file.
+ * @mode: The mode used to open the block special file, likely just FMODE_READ.
+ * @holder: unused
+ *
+ * Return:
+ * On success the @block_device structure otherwise an error created via
+ * ERR_PTR().
+ */
+struct block_device *dattodb_blkdev_by_path(const char *path, fmode_t mode,
+                                        void *holder)
+{
+#if defined HAVE_BLKDEV_GET_BY_PATH_4
+        return blkdev_get_by_path(path, mode, holder, NULL);
+
+#elif defined HAVE_BLKDEV_GET_BY_PATH
+        return blkdev_get_by_path(path, mode, holder);
+
+#else
+        return _blkdev_get_by_path(path, mode, holder);
+#endif
+}

--- a/src/blkdev.c
+++ b/src/blkdev.c
@@ -166,7 +166,7 @@ void dattobd_drop_super(struct super_block *sb)
 /**
  * dattobd_blkdev_put() - Releases a reference to a block device.
  * This function performs the appropriate action based on the available
- * kernel functions to release or drop the superblock.
+ * kernel functions to release block device.
  *
  * @bd: block device structure pointer to be released.
  *

--- a/src/blkdev.h
+++ b/src/blkdev.h
@@ -33,15 +33,12 @@ struct block_device;
 #define dattobd_bdev_size(bdev) part_nr_sects_read((bdev)->bd_part)
 #endif
 
-#ifdef HAVE_BD_SUPER
-#define dattobd_get_super(bdev) (bdev)->bd_super
-#define dattobd_drop_super(sb)
-#else
-#define dattobd_get_super(bdev) get_super(bdev)
-#define dattobd_drop_super(sb) drop_super(sb)
-#endif
 
 struct block_device *dattodb_blkdev_by_path(const char *path, fmode_t mode,
                                         void *holder);
+
+struct super_block *dattobd_get_super(struct block_device * bd);
+
+void dattobd_drop_super(struct super_block *sb);
 
 #endif /* BLKDEV_H_ */

--- a/src/blkdev.h
+++ b/src/blkdev.h
@@ -33,12 +33,6 @@ struct block_device;
 #define dattobd_bdev_size(bdev) part_nr_sects_read((bdev)->bd_part)
 #endif
 
-#ifndef HAVE_BLKDEV_GET_BY_PATH
-//#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
-struct block_device *blkdev_get_by_path(const char *path, fmode_t mode,
-                                        void *holder);
-#endif
-
 #ifdef HAVE_BD_SUPER
 #define dattobd_get_super(bdev) (bdev)->bd_super
 #define dattobd_drop_super(sb)
@@ -46,5 +40,8 @@ struct block_device *blkdev_get_by_path(const char *path, fmode_t mode,
 #define dattobd_get_super(bdev) get_super(bdev)
 #define dattobd_drop_super(sb) drop_super(sb)
 #endif
+
+struct block_device *dattodb_blkdev_by_path(const char *path, fmode_t mode,
+                                        void *holder);
 
 #endif /* BLKDEV_H_ */

--- a/src/blkdev.h
+++ b/src/blkdev.h
@@ -11,13 +11,6 @@
 
 struct block_device;
 
-#ifdef HAVE_BLKDEV_PUT_1
-//#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,28)
-#define dattobd_blkdev_put(bdev) blkdev_put(bdev);
-#else
-#define dattobd_blkdev_put(bdev) blkdev_put(bdev, FMODE_READ);
-#endif
-
 #ifndef bdev_whole
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
 #define bdev_whole(bdev) ((bdev)->bd_contains)
@@ -40,5 +33,7 @@ struct block_device *dattodb_blkdev_by_path(const char *path, fmode_t mode,
 struct super_block *dattobd_get_super(struct block_device * bd);
 
 void dattobd_drop_super(struct super_block *sb);
+
+void dattobd_blkdev_put(struct block_device *bd);
 
 #endif /* BLKDEV_H_ */

--- a/src/configure-tests/feature-tests/bd_has_submit_bio.c
+++ b/src/configure-tests/feature-tests/bd_has_submit_bio.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device* bd;
+	bd->bd_has_submit_bio=false;
+}

--- a/src/configure-tests/feature-tests/bdops_open_with_blk_mode.c
+++ b/src/configure-tests/feature-tests/bdops_open_with_blk_mode.c
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static int snap_open(struct gendisk *gd, blk_mode_t mode){
+	(void)gd;
+	(void)mode;
+	return 0;
+}
+
+static void snap_release(struct gendisk *gd){
+	(void)gd;
+}
+
+static inline void dummy(void){
+	struct gendisk gd;
+	struct block_device_operations bdo = {
+		.open = snap_open,
+		.release = snap_release,
+	};
+
+	bdo.open(&gd, FMODE_READ);
+	bdo.release(&gd);
+}

--- a/src/configure-tests/feature-tests/blkdev_get_by_path_4.c
+++ b/src/configure-tests/feature-tests/blkdev_get_by_path_4.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device *bd = blkdev_get_by_path("path", FMODE_READ, NULL, NULL);
+	if(bd) {
+		blkdev_put(bd, FMODE_READ);
+		bd = NULL;
+	}
+}

--- a/src/configure-tests/feature-tests/blkdev_put_2.c
+++ b/src/configure-tests/feature-tests/blkdev_put_2.c
@@ -9,6 +9,7 @@
 MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
-	struct block_device *bd = blkdev_get_by_path("path", FMODE_READ, NULL, NULL);
-	bd = NULL;
+    struct block_device dev;
+    void* info;
+    blkdev_put(&dev,info);
 }

--- a/src/configure-tests/feature-tests/get_super.c
+++ b/src/configure-tests/feature-tests/get_super.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device bdev;
+	get_super(&bdev);
+}

--- a/src/configure-tests/feature-tests/user_namespace_args_2.c
+++ b/src/configure-tests/feature-tests/user_namespace_args_2.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2023 Datto Inc.
+ * Copyright (C) 2024 Datto Inc.
  */
 
 #include "includes.h"
@@ -9,6 +9,6 @@
 MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
-    struct gendisk *sd_gd = NULL;
-    set_bit(GD_OWNS_QUEUE, &sd_gd->state);
+	struct mnt_idmap* map = &nop_mnt_idmap ;
+	(void)vfs_unlink(map, NULL, NULL, NULL);
 }

--- a/src/configure-tests/symbol-tests
+++ b/src/configure-tests/symbol-tests
@@ -8,3 +8,4 @@ vm_area_alloc
 vm_area_free
 insert_vm_struct
 vm_area_cachep
+get_active_super

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -642,6 +642,7 @@ error:
  * cow_init() - Allocates a &struct cow_manager object and initializes it.
  *              Also creates the COW backing file on disk and writes a
  *              header into it.
+ * @dev:  The &struct snap_device that keeps snapshot device state.
  * @path: The path to the COW file.
  * @elements: typically the number of sectors on the block device.
  * @sect_size: The basic unit of size that the &struct cow_manager works with.
@@ -656,7 +657,7 @@ error:
  * * 0 - success
  * * !0 - errno indicating the error
  */
-int cow_init(const char *path, uint64_t elements, unsigned long sect_size,
+int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsigned long sect_size,
              unsigned long cache_size, uint64_t file_max, const uint8_t *uuid,
              uint64_t seqid, struct cow_manager **cm_out)
 {
@@ -691,6 +692,7 @@ int cow_init(const char *path, uint64_t elements, unsigned long sect_size,
                 __cow_calculate_allowed_sects(cache_size, cm->total_sects);
         cm->data_offset = COW_HEADER_SIZE + (cm->total_sects * (sect_size * 8));
         cm->curr_pos = cm->data_offset / COW_BLOCK_SIZE;
+        cm->dev = dev;
 
         if (uuid)
                 memcpy(cm->uuid, uuid, COW_UUID_SIZE);

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -81,7 +81,7 @@ int cow_reload(const char *path, uint64_t elements, unsigned long sect_size,
                unsigned long cache_size, int index_only,
                struct cow_manager **cm_out);
 
-int cow_init(const char *path, uint64_t elements, unsigned long sect_size,
+int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsigned long sect_size,
              unsigned long cache_size, uint64_t file_max, const uint8_t *uuid,
              uint64_t seqid, struct cow_manager **cm_out);
 

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -662,6 +662,8 @@ static int dattobd_do_truncate(struct dentry *dentry, loff_t length,
 #elif defined HAVE_USER_NAMESPACE_ARGS
         //#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,12,0)
         ret = notify_change(&init_user_ns, dentry, &newattrs, NULL);
+#elif defined HAVE_USER_NAMESPACE_ARGS_2
+        ret = notify_change(&nop_mnt_idmap, dentry, &newattrs, NULL);
 #else
         ret = notify_change(dentry, &newattrs, NULL);
 #endif
@@ -904,6 +906,8 @@ int __file_unlink(struct file *filp, int close, int force)
 #elif defined HAVE_USER_NAMESPACE_ARGS
         //#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,12,0)
         ret = vfs_unlink(&init_user_ns, dir_inode, file_dentry, NULL);
+#elif defined HAVE_USER_NAMESPACE_ARGS_2
+        ret = vfs_unlink(file_mnt_idmap(filp), dir_inode, file_dentry, NULL);
 #else
         ret = vfs_unlink(dir_inode, file_dentry, NULL);
 #endif

--- a/src/ioctl_handlers.c
+++ b/src/ioctl_handlers.c
@@ -100,7 +100,7 @@ int __verify_bdev_writable(const char *bdev_path, int *out)
         struct super_block *sb;
 
         // open the base block device
-        bdev = blkdev_get_by_path(bdev_path, FMODE_READ, NULL);
+        bdev = dattodb_blkdev_by_path(bdev_path, FMODE_READ, NULL);
 
         if (IS_ERR(bdev)) {
                 *out = 0;

--- a/src/snap_device.h
+++ b/src/snap_device.h
@@ -23,6 +23,9 @@
 struct tracing_ops {
 	struct block_device_operations *bd_ops;
 	atomic_t refs;
+#ifdef HAVE_BD_HAS_SUBMIT_BIO
+        bool has_submit_bio;
+#endif
 };
 
 static inline struct tracing_ops* tracing_ops_get(struct tracing_ops *trops) {

--- a/src/snap_ops.c
+++ b/src/snap_ops.c
@@ -64,6 +64,17 @@ static int snap_release(struct gendisk *gd, fmode_t mode)
 {
         return __tracer_close(gd->private_data);
 }
+#elif defined HAVE_BDOPS_OPEN_WITH_BLK_MODE
+static int snap_open(struct gendisk *gd, blk_mode_t mode)
+{
+        (void)mode;
+        return __tracer_open(gd->private_data);
+}
+
+static void snap_release(struct gendisk *gd)
+{
+        __tracer_close(gd->private_data);
+}
 #else
 static int snap_open(struct block_device *bdev, fmode_t mode)
 {

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -730,7 +730,7 @@ static int __tracer_setup_base_dev(struct snap_device *dev,
 
         // open the base block device
         LOG_DEBUG("ENTER __tracer_setup_base_dev");
-        dev->sd_base_dev = blkdev_get_by_path(bdev_path, FMODE_READ, NULL);
+        dev->sd_base_dev = dattodb_blkdev_by_path(bdev_path, FMODE_READ, NULL);
         if (IS_ERR(dev->sd_base_dev)) {
                 ret = PTR_ERR(dev->sd_base_dev);
                 dev->sd_base_dev = NULL;

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -646,7 +646,7 @@ static int __tracer_setup_cow(struct snap_device *dev,
 
                         // create and open the cow manager
                         LOG_DEBUG("creating cow manager");
-                        ret = cow_init(cow_path, SECTOR_TO_BLOCK(size),
+                        ret = cow_init(dev, cow_path, SECTOR_TO_BLOCK(size),
                                        COW_SECTION_SIZE, dev->sd_cache_size,
                                        max_file_size, uuid, seqid,
                                        &dev->sd_cow);
@@ -858,10 +858,11 @@ static void __tracer_copy_cow(const struct snap_device *src,
 {
         dest->sd_cow = src->sd_cow;
         // copy cow file extents and update the device
-	dest->sd_cow_extents = src->sd_cow_extents;
-	dest->sd_cow_ext_cnt = src->sd_cow_ext_cnt;
-
+        dest->sd_cow_extents = src->sd_cow_extents;
+        dest->sd_cow_ext_cnt = src->sd_cow_ext_cnt;
         dest->sd_cow_inode = src->sd_cow_inode;
+        dest->sd_cow->dev = dest;
+
         dest->sd_cache_size = src->sd_cache_size;
         dest->sd_falloc_size = src->sd_falloc_size;
 }


### PR DESCRIPTION
- changes in block_device in kernel
- support new linux kernel function declarations
- support for bd_has_submit_bio for block device