### PR TITLE
fix free_request_tracking_ptr set dev->sd_orig_request_fn as null

### DIFF
--- a/src/tracer.c
+++ b/src/tracer.c
@@ -158,9 +158,8 @@ void dattobd_free_request_tracking_ptr(struct snap_device *dev)
                 tracing_ops_put(dev->sd_tracing_ops);
                 dev->sd_tracing_ops=NULL;
         }
-#else
-        dev->sd_orig_request_fn = NULL;
 #endif
+        dev->sd_orig_request_fn = NULL;
 }
 
 /**


### PR DESCRIPTION
If we are using submit_bio kernel version, we also need to reset `sd_orig_request_fn` to null when  `dattobd_free_request_tracking_ptr` is called. Since `__tracer_destroy_tracing` determined to do destroy traced or not by checking if `sd_orig_request_fn` is a nullptr, not doing this might cause a kernel panic due to double destroy cases.

