### PR TITLE
Fixed mount command for umount-rootfs service

### DIFF
--- a/dist/shutdown/umount_rootfs.shutdown
+++ b/dist/shutdown/umount_rootfs.shutdown
@@ -1,4 +1,4 @@
 #!/bin/sh
-mount -o remount, rw /
+mount -o remount,rw /
 sync
 mount -o remount,ro /


### PR DESCRIPTION
Fixed wrong syntax of `mount` command in `umount-rootfs.service`, which occasionally caused improper close of COW-file.