### PR TITLE
DattoBD 0.11.8 Release

### DIFF
--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -117,7 +117,7 @@
 
 
 Name:            dattobd
-Version:         0.11.7
+Version:         0.11.8
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Datto, Inc.

--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -611,6 +611,13 @@ rm %{_systemd_shutdown}/umount_rootfs.shutdown
 rm %{_systemd_services}/umount-rootfs.service
 
 %changelog
+* Mon Sep 09 2024 Andrii Fylypiuk <andrii.fylypiuk@datto.com> - 0.11.8
+- Fixed compile errors on newer kernels (RPMs Kernels 5.14.0-427.16+)
+- Fixed kernel panic on module unload on systems based on kernels of version 5.0+
+- Fixed kernel panic on module unload on RHEL8-based systems
+- Fixed kernel oops on module unload on Ubuntu 20.04 LTS
+- Fixed problems related to tracking BIOs on systems with multiple block devices on the same general disk 
+
 * Fri Feb 09 2024 Natalia Zelazna <natalia.zelazna@datto.com> - 0.11.7
 - Implement tracking bios in dormant state
 

--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -473,7 +473,7 @@ fi
 if [ ! -d %{_systemd_services}/reboot.target.wants/ ]; then
    mkdir -p %{_systemd_services}/reboot.target.wants
 fi   
-ln -s %{_systemd_services}/umount-rootfs.service   %{_systemd_services}/reboot.target.wants/umount-rootfs.service 
+ln -fs %{_systemd_services}/umount-rootfs.service   %{_systemd_services}/reboot.target.wants/umount-rootfs.service 
 
 %postun -n %{libname}
 /sbin/ldconfig
@@ -517,7 +517,7 @@ rm -rf %{buildroot}
 
 
 %post 
-ln -s %{_systemd_services}/umount-rootfs.service   %{_systemd_services}/reboot.target.wants/umount-rootfs.service 
+ln -fs %{_systemd_services}/umount-rootfs.service   %{_systemd_services}/reboot.target.wants/umount-rootfs.service 
 
 %doc README.md doc/STRUCTURE.md
 %if "%{_vendor}" == "redhat"

--- a/src/bdev_state_handler.c
+++ b/src/bdev_state_handler.c
@@ -122,7 +122,7 @@ int __handle_bdev_mount_writable(const char *dir_name,
                 if (test_bit(UNVERIFIED, &dev->sd_state)) {
                         // get the block device for the unverified tracer we are
                         // looking into
-                        cur_bdev = blkdev_get_by_path(dev->sd_bdev_path,
+                        cur_bdev = dattodb_blkdev_by_path(dev->sd_bdev_path,
                                                       FMODE_READ, NULL);
                         if (IS_ERR(cur_bdev)) {
                                 cur_bdev = NULL;
@@ -257,7 +257,7 @@ void post_umount_check(int dormant_ret, int umount_ret, unsigned int idx,
         // reactivate
         if (umount_ret) {
                 struct block_device *bdev;
-                bdev = blkdev_get_by_path(dev->sd_bdev_path, FMODE_READ, NULL);
+                bdev = dattodb_blkdev_by_path(dev->sd_bdev_path, FMODE_READ, NULL);
                 if (!bdev || IS_ERR(bdev)) {
                         LOG_DEBUG("device gone, moving to error state");
                         tracer_set_fail_state(dev, -ENODEV);

--- a/src/bdev_state_handler.c
+++ b/src/bdev_state_handler.c
@@ -28,7 +28,7 @@ void auto_transition_active(unsigned int minor, const char *dir_name)
 {
         struct snap_device *dev = snap_devices[minor];
 
-LOG_DEBUG("ENTER %s minor: %d", __func__, minor);
+        LOG_DEBUG("ENTER %s minor: %d", __func__, minor);
         mutex_lock(&ioctl_mutex);
 
         if (test_bit(UNVERIFIED, &dev->sd_state)) {
@@ -107,8 +107,7 @@ int __handle_bdev_mount_writable(const char *dir_name,
         struct snap_device *dev;
         struct block_device *cur_bdev;
 
-        LOG_DEBUG("ENTER __handle_bdev_mount_writable");
-
+        LOG_DEBUG("ENTER %s", __func__);
         tracer_for_each(dev, i)
         {
                 if (!dev || test_bit(ACTIVE, &dev->sd_state) ||
@@ -159,7 +158,7 @@ int __handle_bdev_mount_writable(const char *dir_name,
         ret = -ENODEV;
 
 out:
-        LOG_DEBUG("EXIT __handle_bdev_mount_writable");
+        LOG_DEBUG("EXIT %s", __func__);
         *idx_out = i;
         return ret;
 }
@@ -194,6 +193,10 @@ int handle_bdev_mount_event(const char *dir_name, int follow_flags,
 #else
         ret = user_path_at(AT_FDCWD, dir_name, lookup_flags, &path);
 #endif //LINUX_VERSION_CODE
+        if (ret) {
+                LOG_DEBUG("error finding path");
+                goto out;
+        }
 
         LOG_DEBUG("path->dentry: %s, path->mnt->mnt_root: %s", path.dentry->d_name.name, path.mnt->mnt_root->d_name.name);
 
@@ -245,10 +248,10 @@ void post_umount_check(int dormant_ret, int umount_ret, unsigned int idx,
         struct snap_device *dev;
         struct super_block *sb;
 
-        //LOG_DEBUG("ENTER %s", __func__);
+        LOG_DEBUG("ENTER %s", __func__);
         // if we didn't do anything or failed, just return
-        if (dormant_ret){
-                //LOG_DEBUG("dormant_ret");
+        if (dormant_ret) {
+                LOG_DEBUG("EXIT %s, dormant_ret", __func__);
                 return;
         }
         dev = snap_devices[idx];

--- a/src/bio_helper.c
+++ b/src/bio_helper.c
@@ -124,7 +124,7 @@ void dattobd_set_bio_ops(struct bio *bio, req_op_t op, unsigned op_flags)
 }
 #endif
 
-#ifndef HAVE_BIO_BI_OPF 
+#if !defined(HAVE_BIO_BI_OPF) && defined(HAVE_ENUM_REQ_OP)
 void dattobd_set_bio_ops(struct bio *bio, req_op_t op, unsigned op_flags)
 {
        bio->bi_rw = 0;

--- a/src/bio_request_callback.h
+++ b/src/bio_request_callback.h
@@ -38,6 +38,7 @@
 #define BIO_REQUEST_CALLBACK_FN make_request_fn
 #define SUBMIT_BIO_REAL dattobd_call_mrf_real
 #define GET_BIO_REQUEST_TRACKING_PTR dattobd_get_bd_mrf
+#define GET_BIO_REQUEST_TRACKING_PTR_GD dattobd_get_gd_mrf
 #define SET_BIO_REQUEST_TRACKING_PTR dattobd_set_bd_mrf
 #endif
 

--- a/src/bio_request_callback.h
+++ b/src/bio_request_callback.h
@@ -39,7 +39,8 @@
 #define SUBMIT_BIO_REAL dattobd_call_mrf_real
 #define GET_BIO_REQUEST_TRACKING_PTR dattobd_get_bd_mrf
 #define GET_BIO_REQUEST_TRACKING_PTR_GD dattobd_get_gd_mrf
-#define SET_BIO_REQUEST_TRACKING_PTR dattobd_set_bd_mrf
+// deprecated, as we have not found usage
+// #define SET_BIO_REQUEST_TRACKING_PTR dattobd_set_bd_mrf
 #endif
 
 #endif

--- a/src/blkdev.c
+++ b/src/blkdev.c
@@ -80,11 +80,7 @@ static struct block_device *_blkdev_get_by_path(const char *pathname, fmode_t mo
                 return bdev;
 
         if ((mode & FMODE_WRITE) && bdev_read_only(bdev)) {
-#ifdef HAVE_BLKDEV_PUT_1
-                blkdev_put(bdev);
-#else
-                blkdev_put(bdev, mode);
-#endif
+                dattobd_blkdev_put(bdev);
                 return ERR_PTR(-EACCES);
         }
 
@@ -164,5 +160,28 @@ void dattobd_drop_super(struct super_block *sb)
 
 #else
         return;
+#endif
+}
+
+/**
+ * dattobd_blkdev_put() - Releases a reference to a block device.
+ * This function performs the appropriate action based on the available
+ * kernel functions to release or drop the superblock.
+ *
+ * @bd: block device structure pointer to be released.
+ *
+ * Return:
+ * void.
+ */
+void dattobd_blkdev_put(struct block_device *bd) 
+{
+#if defined HAVE_BLKDEV_PUT_1
+        return blkdev_put(bd);
+
+#elif defined HAVE_BLKDEV_PUT_2
+        return blkdev_put(bd,NULL);
+
+#else
+        return blkdev_put(bd, FMODE_READ);
 #endif
 }

--- a/src/blkdev.c
+++ b/src/blkdev.c
@@ -5,6 +5,7 @@
  */
 
 #include "blkdev.h"
+#include "logging.h"
 
 #if !defined HAVE_BLKDEV_GET_BY_PATH && !defined HAVE_BLKDEV_GET_BY_PATH_4
 
@@ -187,7 +188,7 @@ void dattobd_blkdev_put(struct block_device *bd)
 }
 
 /**
- * dattobd_get_start_sect_by_gendisk() - Get starting sector of partition according to gendisk and partition number. 
+ * dattobd_get_start_sect_by_gendisk_for_bio() - Get starting sector of partition according to gendisk and partition number. 
  * 
  * @gd: gendisk
  * @partno: partition number
@@ -196,7 +197,7 @@ void dattobd_blkdev_put(struct block_device *bd)
  * Result:
  * 0 on success, error otherwise
  */
-int dattobd_get_start_sect_by_gendisk(struct gendisk* gd, u8 partno, sector_t* result){
+int dattobd_get_start_sect_by_gendisk_for_bio(struct gendisk* gd, u8 partno, sector_t* result){
 #if defined HAVE_BDGET_DISK
         struct block_device* bd = bdget_disk(gd, partno);
         if(!bd)
@@ -213,6 +214,10 @@ int dattobd_get_start_sect_by_gendisk(struct gendisk* gd, u8 partno, sector_t* r
 #elif defined HAVE_GENDISK_PART
         *result = gd->part[partno]->start_sect;
         return 0;
+#elif defined HAVE_BIO_BI_BDEV
+        // Unreachable
+        LOG_ERROR(-1, "Unreachable code.");
+        return -1;
 #else
         #error Could not determine starting sector of partition by gendisk and partition number
 #endif

--- a/src/blkdev.c
+++ b/src/blkdev.c
@@ -197,18 +197,18 @@ void dattobd_blkdev_put(struct block_device *bd)
  * 0 on success, error otherwise
  */
 int dattobd_get_start_sect_by_gendisk(struct gendisk* gd, u8 partno, sector_t* result){
-#if defined HAVE_DISK_GET_PART
+#if defined HAVE_BDGET_DISK
+        struct block_device* bd = bdget_disk(gd, partno);
+        if(!bd)
+                return -1;
+        *result = get_start_sect(bd);
+        return 0;
+#elif defined HAVE_DISK_GET_PART
         struct hd_struct* hd = disk_get_part(gd, partno);
         if(!hd)
                 return -1;
         *result = hd->start_sect;
         disk_put_part(hd);
-        return 0;
-#elif defined HAVE_BDGET_DISK
-        struct block_device* bd = bdget_disk(gd, partno);
-        if(!bd)
-                return -1;
-        *result = get_start_sect(bd);
         return 0;
 #elif defined HAVE_GENDISK_PART
         *result = gd->part[partno]->start_sect;

--- a/src/blkdev.c
+++ b/src/blkdev.c
@@ -6,7 +6,7 @@
 
 #include "blkdev.h"
 
-#ifndef HAVE_BLKDEV_GET_BY_PATH
+#if !defined HAVE_BLKDEV_GET_BY_PATH && !defined HAVE_BLKDEV_GET_BY_PATH_4
 
 /**
  * dattobd_lookup_bdev() - Looks up the inode associated with the path, verifies
@@ -58,13 +58,8 @@ fail:
         goto out;
 }
 
-#endif
-
-#ifndef HAVE_BLKDEV_GET_BY_PATH
-//#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
-
 /**
- * blkdev_get_by_path() - Fetches the @block_device struct associated with the
+ * _blkdev_get_by_path() - Fetches the @block_device struct associated with the
  * @pathname.  This is very similar to @dattobd_lookup_bdev with minor
  * additional validation.
  *
@@ -76,7 +71,7 @@ fail:
  * On success the @block_device structure otherwise an error created via
  * ERR_PTR().
  */
-struct block_device *blkdev_get_by_path(const char *pathname, fmode_t mode,
+static struct block_device *_blkdev_get_by_path(const char *pathname, fmode_t mode,
                                         void *holder)
 {
         struct block_device *bdev;
@@ -97,3 +92,30 @@ struct block_device *blkdev_get_by_path(const char *pathname, fmode_t mode,
 }
 
 #endif
+
+/**
+ * dattodb_blkdev_by_path() - Fetches the @block_device struct associated with the
+ * @path. This function uses different methods based on available kernel functions
+ * to retrieve the block device.
+ *
+ * @path: the path name of a block special file.
+ * @mode: The mode used to open the block special file, likely just FMODE_READ.
+ * @holder: unused
+ *
+ * Return:
+ * On success the @block_device structure otherwise an error created via
+ * ERR_PTR().
+ */
+struct block_device *dattodb_blkdev_by_path(const char *path, fmode_t mode,
+                                        void *holder)
+{
+#if defined HAVE_BLKDEV_GET_BY_PATH_4
+        return blkdev_get_by_path(path, mode, holder, NULL);
+
+#elif defined HAVE_BLKDEV_GET_BY_PATH
+        return blkdev_get_by_path(path, mode, holder);
+
+#else
+        return _blkdev_get_by_path(path, mode, holder);
+#endif
+}

--- a/src/blkdev.c
+++ b/src/blkdev.c
@@ -166,7 +166,7 @@ void dattobd_drop_super(struct super_block *sb)
 /**
  * dattobd_blkdev_put() - Releases a reference to a block device.
  * This function performs the appropriate action based on the available
- * kernel functions to release or drop the superblock.
+ * kernel functions to release block device.
  *
  * @bd: block device structure pointer to be released.
  *

--- a/src/blkdev.c
+++ b/src/blkdev.c
@@ -185,3 +185,35 @@ void dattobd_blkdev_put(struct block_device *bd)
         return blkdev_put(bd, FMODE_READ);
 #endif
 }
+
+/**
+ * dattobd_get_start_sect_by_gendisk() - Get starting sector of partition according to gendisk and partition number. 
+ * 
+ * @gd: gendisk
+ * @partno: partition number
+ * @result: pointer to place result
+ * 
+ * Result:
+ * 0 on success, error otherwise
+ */
+int dattobd_get_start_sect_by_gendisk(struct gendisk* gd, u8 partno, sector_t* result){
+#if defined HAVE_DISK_GET_PART
+        struct hd_struct* hd = disk_get_part(gd, partno);
+        if(!hd)
+                return -1;
+        *result = hd->start_sect;
+        disk_put_part(hd);
+        return 0;
+#elif defined HAVE_BDGET_DISK
+        struct block_device* bd = bdget_disk(gd, partno);
+        if(!bd)
+                return -1;
+        *result = get_start_sect(bd);
+        return 0;
+#elif defined HAVE_GENDISK_PART
+        *result = gd->part[partno]->start_sect;
+        return 0;
+#else
+        #error Could not determine starting sector of partition by gendisk and partition number
+#endif
+}

--- a/src/blkdev.h
+++ b/src/blkdev.h
@@ -36,4 +36,5 @@ void dattobd_drop_super(struct super_block *sb);
 
 void dattobd_blkdev_put(struct block_device *bd);
 
+int dattobd_get_start_sect_by_gendisk(struct gendisk* gd, u8 partno, sector_t* result);
 #endif /* BLKDEV_H_ */

--- a/src/blkdev.h
+++ b/src/blkdev.h
@@ -33,15 +33,12 @@ struct block_device;
 #define dattobd_bdev_size(bdev) part_nr_sects_read((bdev)->bd_part)
 #endif
 
-#ifdef HAVE_BD_SUPER
-#define dattobd_get_super(bdev) (bdev)->bd_super
-#define dattobd_drop_super(sb)
-#else
-#define dattobd_get_super(bdev) get_super(bdev)
-#define dattobd_drop_super(sb) drop_super(sb)
-#endif
 
 struct block_device *dattodb_blkdev_by_path(const char *path, fmode_t mode,
                                         void *holder);
+
+struct super_block *dattobd_get_super(struct block_device * bd);
+
+void dattobd_drop_super(struct super_block *sb);
 
 #endif /* BLKDEV_H_ */

--- a/src/blkdev.h
+++ b/src/blkdev.h
@@ -33,12 +33,6 @@ struct block_device;
 #define dattobd_bdev_size(bdev) part_nr_sects_read((bdev)->bd_part)
 #endif
 
-#ifndef HAVE_BLKDEV_GET_BY_PATH
-//#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,38)
-struct block_device *blkdev_get_by_path(const char *path, fmode_t mode,
-                                        void *holder);
-#endif
-
 #ifdef HAVE_BD_SUPER
 #define dattobd_get_super(bdev) (bdev)->bd_super
 #define dattobd_drop_super(sb)
@@ -46,5 +40,8 @@ struct block_device *blkdev_get_by_path(const char *path, fmode_t mode,
 #define dattobd_get_super(bdev) get_super(bdev)
 #define dattobd_drop_super(sb) drop_super(sb)
 #endif
+
+struct block_device *dattodb_blkdev_by_path(const char *path, fmode_t mode,
+                                        void *holder);
 
 #endif /* BLKDEV_H_ */

--- a/src/blkdev.h
+++ b/src/blkdev.h
@@ -36,5 +36,5 @@ void dattobd_drop_super(struct super_block *sb);
 
 void dattobd_blkdev_put(struct block_device *bd);
 
-int dattobd_get_start_sect_by_gendisk(struct gendisk* gd, u8 partno, sector_t* result);
+int dattobd_get_start_sect_by_gendisk_for_bio(struct gendisk* gd, u8 partno, sector_t* result);
 #endif /* BLKDEV_H_ */

--- a/src/blkdev.h
+++ b/src/blkdev.h
@@ -11,13 +11,6 @@
 
 struct block_device;
 
-#ifdef HAVE_BLKDEV_PUT_1
-//#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,28)
-#define dattobd_blkdev_put(bdev) blkdev_put(bdev);
-#else
-#define dattobd_blkdev_put(bdev) blkdev_put(bdev, FMODE_READ);
-#endif
-
 #ifndef bdev_whole
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
 #define bdev_whole(bdev) ((bdev)->bd_contains)
@@ -40,5 +33,7 @@ struct block_device *dattodb_blkdev_by_path(const char *path, fmode_t mode,
 struct super_block *dattobd_get_super(struct block_device * bd);
 
 void dattobd_drop_super(struct super_block *sb);
+
+void dattobd_blkdev_put(struct block_device *bd);
 
 #endif /* BLKDEV_H_ */

--- a/src/callback_refs.c
+++ b/src/callback_refs.c
@@ -9,7 +9,7 @@
 #ifndef USE_BDOPS_SUBMIT_BIO
 
 struct mrf_tracking_data {
-        const struct block_device *mtd_disk;
+        const struct gendisk *mtd_disk;
         BIO_REQUEST_CALLBACK_FN *mtd_orig;
         atomic_t mtd_count;
         struct hlist_node node;
@@ -22,7 +22,7 @@ void mrf_tracking_init(void) {
         hash_init(mrf_tracking_map);
 }
 
-static struct mrf_tracking_data* get_a_node(const struct block_device *disk)
+static struct mrf_tracking_data* get_a_node(const struct gendisk *disk)
 {
         unsigned int bkt = 0;
         struct mrf_tracking_data *cur = NULL;
@@ -34,7 +34,7 @@ static struct mrf_tracking_data* get_a_node(const struct block_device *disk)
         return NULL;
 }
 
-int mrf_get(const struct block_device *disk, BIO_REQUEST_CALLBACK_FN *fn) 
+int mrf_get(const struct gendisk *disk, BIO_REQUEST_CALLBACK_FN *fn) 
 {
         struct mrf_tracking_data* mtd = get_a_node(disk);
         if (!mtd) {
@@ -53,7 +53,7 @@ int mrf_get(const struct block_device *disk, BIO_REQUEST_CALLBACK_FN *fn)
         return 0;
 }
 
-const BIO_REQUEST_CALLBACK_FN* mrf_put(struct block_device *disk)
+const BIO_REQUEST_CALLBACK_FN* mrf_put(struct gendisk *disk)
 {
         BIO_REQUEST_CALLBACK_FN *fn = NULL;
         struct mrf_tracking_data *mtd = get_a_node(disk);
@@ -69,7 +69,7 @@ const BIO_REQUEST_CALLBACK_FN* mrf_put(struct block_device *disk)
         }
         
         // return the current mrf to make swap logic easier
-        return (const BIO_REQUEST_CALLBACK_FN*) GET_BIO_REQUEST_TRACKING_PTR(disk);
+        return (const BIO_REQUEST_CALLBACK_FN*) GET_BIO_REQUEST_TRACKING_PTR_GD(disk);
 }
 
 #endif

--- a/src/callback_refs.h
+++ b/src/callback_refs.h
@@ -28,7 +28,7 @@ void mrf_tracking_init(void);
  *
  * Return: 0 on success. Non-zero otherwise.
  */
-int mrf_get(const struct block_device* disk, BIO_REQUEST_CALLBACK_FN* fn);
+int mrf_get(const struct gendisk* disk, BIO_REQUEST_CALLBACK_FN* fn);
 
 /**
  * mrf_put() - Decrements the reference count and returns mrf
@@ -37,7 +37,7 @@ int mrf_get(const struct block_device* disk, BIO_REQUEST_CALLBACK_FN* fn);
  * 
  * Return: Returns the mrf for the block device or NULL on error.
  */
-const BIO_REQUEST_CALLBACK_FN* mrf_put(struct block_device* disk);
+const BIO_REQUEST_CALLBACK_FN* mrf_put(struct gendisk* disk);
 
 #endif // USE_BDOPS_SUBMIT_BIO
 #endif // CALLBACK_REFS_H_

--- a/src/configure-tests/feature-tests/bd_has_submit_bio.c
+++ b/src/configure-tests/feature-tests/bd_has_submit_bio.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device* bd;
+	bd->bd_has_submit_bio=false;
+}

--- a/src/configure-tests/feature-tests/bdget_disk.c
+++ b/src/configure-tests/feature-tests/bdget_disk.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct gendisk* gd;
+    u8 partno;
+    struct block_device* bd;
+    bd = bdget_disk(gd, partno);
+}

--- a/src/configure-tests/feature-tests/bdops_open_with_blk_mode.c
+++ b/src/configure-tests/feature-tests/bdops_open_with_blk_mode.c
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static int snap_open(struct gendisk *gd, blk_mode_t mode){
+	(void)gd;
+	(void)mode;
+	return 0;
+}
+
+static void snap_release(struct gendisk *gd){
+	(void)gd;
+}
+
+static inline void dummy(void){
+	struct gendisk gd;
+	struct block_device_operations bdo = {
+		.open = snap_open,
+		.release = snap_release,
+	};
+
+	bdo.open(&gd, FMODE_READ);
+	bdo.release(&gd);
+}

--- a/src/configure-tests/feature-tests/bio_bi_partno.c
+++ b/src/configure-tests/feature-tests/bio_bi_partno.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct bio bio;
+	bio.bi_partno = 0;
+}

--- a/src/configure-tests/feature-tests/blk_alloc_queue_1.c
+++ b/src/configure-tests/feature-tests/blk_alloc_queue_1.c
@@ -10,4 +10,5 @@ MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
     struct request_queue *rq = blk_alloc_queue(GFP_KERNEL);
+    (void)rq;
 }

--- a/src/configure-tests/feature-tests/blkdev_get_by_path_4.c
+++ b/src/configure-tests/feature-tests/blkdev_get_by_path_4.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device *bd = blkdev_get_by_path("path", FMODE_READ, NULL, NULL);
+	if(bd) {
+		blkdev_put(bd, FMODE_READ);
+		bd = NULL;
+	}
+}

--- a/src/configure-tests/feature-tests/blkdev_put_2.c
+++ b/src/configure-tests/feature-tests/blkdev_put_2.c
@@ -9,6 +9,7 @@
 MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
-	struct block_device *bd = blkdev_get_by_path("path", FMODE_READ, NULL, NULL);
-	bd = NULL;
+    struct block_device dev;
+    void* info;
+    blkdev_put(&dev,info);
 }

--- a/src/configure-tests/feature-tests/disk_get_part.c
+++ b/src/configure-tests/feature-tests/disk_get_part.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct gendisk* gd;
+    u8 partno;
+    struct hd_struct* hd;
+    hd = disk_get_part(gd, partno);
+}

--- a/src/configure-tests/feature-tests/gendisk_part.c
+++ b/src/configure-tests/feature-tests/gendisk_part.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct gendisk* gd;
+    struct hd_struct **part;
+    gd->part = part;
+}

--- a/src/configure-tests/feature-tests/get_super.c
+++ b/src/configure-tests/feature-tests/get_super.c
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device bdev;
+	get_super(&bdev);
+}

--- a/src/configure-tests/feature-tests/user_namespace_args_2.c
+++ b/src/configure-tests/feature-tests/user_namespace_args_2.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 /*
- * Copyright (C) 2023 Datto Inc.
+ * Copyright (C) 2024 Datto Inc.
  */
 
 #include "includes.h"
@@ -9,6 +9,6 @@
 MODULE_LICENSE("GPL");
 
 static inline void dummy(void){
-    struct gendisk *sd_gd = NULL;
-    set_bit(GD_OWNS_QUEUE, &sd_gd->state);
+	struct mnt_idmap* map = &nop_mnt_idmap ;
+	(void)vfs_unlink(map, NULL, NULL, NULL);
 }

--- a/src/configure-tests/symbol-tests
+++ b/src/configure-tests/symbol-tests
@@ -8,3 +8,4 @@ vm_area_alloc
 vm_area_free
 insert_vm_struct
 vm_area_cachep
+get_active_super

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -642,6 +642,7 @@ error:
  * cow_init() - Allocates a &struct cow_manager object and initializes it.
  *              Also creates the COW backing file on disk and writes a
  *              header into it.
+ * @dev:  The &struct snap_device that keeps snapshot device state.
  * @path: The path to the COW file.
  * @elements: typically the number of sectors on the block device.
  * @sect_size: The basic unit of size that the &struct cow_manager works with.
@@ -656,7 +657,7 @@ error:
  * * 0 - success
  * * !0 - errno indicating the error
  */
-int cow_init(const char *path, uint64_t elements, unsigned long sect_size,
+int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsigned long sect_size,
              unsigned long cache_size, uint64_t file_max, const uint8_t *uuid,
              uint64_t seqid, struct cow_manager **cm_out)
 {
@@ -691,6 +692,7 @@ int cow_init(const char *path, uint64_t elements, unsigned long sect_size,
                 __cow_calculate_allowed_sects(cache_size, cm->total_sects);
         cm->data_offset = COW_HEADER_SIZE + (cm->total_sects * (sect_size * 8));
         cm->curr_pos = cm->data_offset / COW_BLOCK_SIZE;
+        cm->dev = dev;
 
         if (uuid)
                 memcpy(cm->uuid, uuid, COW_UUID_SIZE);

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -81,7 +81,7 @@ int cow_reload(const char *path, uint64_t elements, unsigned long sect_size,
                unsigned long cache_size, int index_only,
                struct cow_manager **cm_out);
 
-int cow_init(const char *path, uint64_t elements, unsigned long sect_size,
+int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsigned long sect_size,
              unsigned long cache_size, uint64_t file_max, const uint8_t *uuid,
              uint64_t seqid, struct cow_manager **cm_out);
 

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -15,7 +15,7 @@
 #include <linux/limits.h>
 #include <linux/types.h>
 
-#define DATTOBD_VERSION "0.11.7"
+#define DATTOBD_VERSION "0.11.8"
 #define DATTO_IOCTL_MAGIC 0x91
 
 struct setup_params {

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -662,6 +662,8 @@ static int dattobd_do_truncate(struct dentry *dentry, loff_t length,
 #elif defined HAVE_USER_NAMESPACE_ARGS
         //#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,12,0)
         ret = notify_change(&init_user_ns, dentry, &newattrs, NULL);
+#elif defined HAVE_USER_NAMESPACE_ARGS_2
+        ret = notify_change(&nop_mnt_idmap, dentry, &newattrs, NULL);
 #else
         ret = notify_change(dentry, &newattrs, NULL);
 #endif
@@ -904,6 +906,8 @@ int __file_unlink(struct file *filp, int close, int force)
 #elif defined HAVE_USER_NAMESPACE_ARGS
         //#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,12,0)
         ret = vfs_unlink(&init_user_ns, dir_inode, file_dentry, NULL);
+#elif defined HAVE_USER_NAMESPACE_ARGS_2
+        ret = vfs_unlink(file_mnt_idmap(filp), dir_inode, file_dentry, NULL);
 #else
         ret = vfs_unlink(dir_inode, file_dentry, NULL);
 #endif

--- a/src/includes.h
+++ b/src/includes.h
@@ -24,5 +24,6 @@
 #include <linux/unistd.h>
 #include <linux/vmalloc.h>
 #include <linux/fiemap.h>
+#include <linux/types.h>
 
 #endif

--- a/src/ioctl_handlers.c
+++ b/src/ioctl_handlers.c
@@ -100,7 +100,7 @@ int __verify_bdev_writable(const char *bdev_path, int *out)
         struct super_block *sb;
 
         // open the base block device
-        bdev = blkdev_get_by_path(bdev_path, FMODE_READ, NULL);
+        bdev = dattodb_blkdev_by_path(bdev_path, FMODE_READ, NULL);
 
         if (IS_ERR(bdev)) {
                 *out = 0;

--- a/src/mrf.c
+++ b/src/mrf.c
@@ -109,8 +109,8 @@ int dattobd_call_mrf(make_request_fn *fn, struct request_queue *q,
         return 0;
 }
 
-make_request_fn* dattobd_get_bd_mrf(struct block_device *bdev){
-	return bdev->bd_disk->fops->submit_bio;
+make_request_fn* dattobd_get_gd_mrf(struct gendisk *gd){
+	return gd->fops->submit_bio;
 }
 
 struct block_device_operations* dattobd_get_bd_ops(struct block_device *bdev){
@@ -126,8 +126,12 @@ int dattobd_call_mrf_real(struct snap_device *dev, struct bio *bio)
         bio);
 }
 
-make_request_fn* dattobd_get_bd_mrf(struct block_device *bdev)
+make_request_fn* dattobd_get_gd_mrf(struct gendisk *gd)
 {
-    return bdev->bd_disk->queue->make_request_fn;
+    return gd->queue->make_request_fn;
 }
 #endif
+
+make_request_fn* dattobd_get_bd_mrf(struct block_device *bdev){
+    return dattobd_get_gd_mrf(bdev->bd_disk);
+}

--- a/src/mrf.h
+++ b/src/mrf.h
@@ -52,13 +52,13 @@ MRF_RETURN_TYPE dattobd_null_mrf(struct request_queue *q, struct bio *bio);
 #ifdef USE_BDOPS_SUBMIT_BIO
 MRF_RETURN_TYPE dattobd_snap_null_mrf(struct bio *bio);
 MRF_RETURN_TYPE dattobd_null_mrf(struct bio *bio);
-make_request_fn* dattobd_get_bd_mrf(struct block_device *bdev);
+make_request_fn* dattobd_get_gd_mrf(struct gendisk *gd);
 struct block_device_operations* dattobd_get_bd_ops(struct block_device *bdev);
 void dattobd_set_bd_mrf(struct block_device *bdev, make_request_fn *mrf);
 int dattobd_call_mrf_real(struct snap_device *dev, struct bio *bio);
 int dattobd_call_mrf(make_request_fn *fn, struct request_queue *q, struct bio *bio);
 #else
-make_request_fn* dattobd_get_bd_mrf(struct block_device *bdev);
+make_request_fn* dattobd_get_gd_mrf(struct gendisk *gd);
 
 
 /**
@@ -77,4 +77,7 @@ make_request_fn* dattobd_get_bd_mrf(struct block_device *bdev);
  */
 int dattobd_call_mrf_real(struct snap_device *dev, struct bio *bio);
 #endif
+
+make_request_fn* dattobd_get_bd_mrf(struct block_device *bdev);
+
 #endif /* MRF_H_ */

--- a/src/snap_device.h
+++ b/src/snap_device.h
@@ -23,6 +23,9 @@
 struct tracing_ops {
 	struct block_device_operations *bd_ops;
 	atomic_t refs;
+#ifdef HAVE_BD_HAS_SUBMIT_BIO
+        bool has_submit_bio;
+#endif
 };
 
 static inline struct tracing_ops* tracing_ops_get(struct tracing_ops *trops) {

--- a/src/snap_ops.c
+++ b/src/snap_ops.c
@@ -64,6 +64,17 @@ static int snap_release(struct gendisk *gd, fmode_t mode)
 {
         return __tracer_close(gd->private_data);
 }
+#elif defined HAVE_BDOPS_OPEN_WITH_BLK_MODE
+static int snap_open(struct gendisk *gd, blk_mode_t mode)
+{
+        (void)mode;
+        return __tracer_open(gd->private_data);
+}
+
+static void snap_release(struct gendisk *gd)
+{
+        __tracer_close(gd->private_data);
+}
 #else
 static int snap_open(struct block_device *bdev, fmode_t mode)
 {

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1345,7 +1345,7 @@ static int __tracer_transition_tracing(
         bdev->bd_has_submit_bio=dev->sd_tracing_ops->has_submit_bio;
 #endif
 #endif
-                *dev_ptr = dev;
+                *dev_ptr = NULL;
                 smp_wmb();
         }
         if(origsb){

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -730,7 +730,7 @@ static int __tracer_setup_base_dev(struct snap_device *dev,
 
         // open the base block device
         LOG_DEBUG("ENTER __tracer_setup_base_dev");
-        dev->sd_base_dev = blkdev_get_by_path(bdev_path, FMODE_READ, NULL);
+        dev->sd_base_dev = dattodb_blkdev_by_path(bdev_path, FMODE_READ, NULL);
         if (IS_ERR(dev->sd_base_dev)) {
                 ret = PTR_ERR(dev->sd_base_dev);
                 dev->sd_base_dev = NULL;

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1332,7 +1332,7 @@ static int __tracer_transition_tracing(
                 LOG_DEBUG("ending tracing");
                 atomic_dec(&(*dev_ptr)->sd_active);
 #ifndef USE_BDOPS_SUBMIT_BIO
-                new_bio_tracking_ptr = mrf_put(bdev);
+                new_bio_tracking_ptr = mrf_put(bdev->bd_disk);
                 if (new_bio_tracking_ptr){
                         bdev->bd_disk->queue->make_request_fn =
                                 new_bio_tracking_ptr;
@@ -1879,7 +1879,7 @@ int tracer_setup_active_snap(struct snap_device *dev, unsigned int minor,
 
 #ifndef USE_BDOPS_SUBMIT_BIO
         // retain an association between the original mrf and the block device
-        ret = mrf_get(dev->sd_base_dev, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev));
+        ret = mrf_get(dev->sd_base_dev->bd_disk, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev));
         if (ret)
                 goto error;
 #endif
@@ -2242,7 +2242,7 @@ void __tracer_unverified_snap_to_active(struct snap_device *dev,
 
 #ifndef USE_BDOPS_SUBMIT_BIO
         // retain an association between the original mrf and the block device
-        ret = mrf_get(dev->sd_base_dev, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev));
+        ret = mrf_get(dev->sd_base_dev->bd_disk, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev));
         if (ret)
                 goto error;
 #endif
@@ -2338,7 +2338,7 @@ void __tracer_unverified_inc_to_active(struct snap_device *dev,
 
 #ifndef USE_BDOPS_SUBMIT_BIO
         // retain an association between the original mrf and the block device
-        ret = mrf_get(dev->sd_base_dev, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev));
+        ret = mrf_get(dev->sd_base_dev->bd_disk, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev));
         if (ret)
                 goto error;
 #endif

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -646,7 +646,7 @@ static int __tracer_setup_cow(struct snap_device *dev,
 
                         // create and open the cow manager
                         LOG_DEBUG("creating cow manager");
-                        ret = cow_init(cow_path, SECTOR_TO_BLOCK(size),
+                        ret = cow_init(dev, cow_path, SECTOR_TO_BLOCK(size),
                                        COW_SECTION_SIZE, dev->sd_cache_size,
                                        max_file_size, uuid, seqid,
                                        &dev->sd_cow);
@@ -858,10 +858,11 @@ static void __tracer_copy_cow(const struct snap_device *src,
 {
         dest->sd_cow = src->sd_cow;
         // copy cow file extents and update the device
-	dest->sd_cow_extents = src->sd_cow_extents;
-	dest->sd_cow_ext_cnt = src->sd_cow_ext_cnt;
-
+        dest->sd_cow_extents = src->sd_cow_extents;
+        dest->sd_cow_ext_cnt = src->sd_cow_ext_cnt;
         dest->sd_cow_inode = src->sd_cow_inode;
+        dest->sd_cow->dev = dest;
+
         dest->sd_cache_size = src->sd_cache_size;
         dest->sd_falloc_size = src->sd_falloc_size;
 }

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1420,10 +1420,6 @@ static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
                                 goto out;
                         }
                 } 
-#ifndef USE_BDOPS_SUBMIT_BIO
-        ret = SUBMIT_BIO_REAL(dev, bio);
-        goto out;
-#endif
         } // tracer_for_each(dev, i)
 
 #ifdef USE_BDOPS_SUBMIT_BIO
@@ -1440,6 +1436,13 @@ static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
         else{
                 submit_bio_noacct( bio);
         }
+#else
+        tracer_for_each(dev, i){
+		if(!tracer_is_bio_for_dev_only_queue(dev, bio)) continue;
+                ret = SUBMIT_BIO_REAL(dev, bio);
+                goto out;
+        }
+	LOG_WARN("caught bio without original mrf to pass!");
 #endif
 
 out:

--- a/src/tracer_helper.c
+++ b/src/tracer_helper.c
@@ -47,7 +47,7 @@ bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio)
                 return false;
 
 #if defined HAVE_BIO_BI_BDEV
-        if(unlikely(bi->bdev) == NULL)
+        if(unlikely(bi->bdev == NULL))
                 return false;
         bio_sector_start += get_start_sect(bio->bi_bdev);
 #elif defined HAVE_BIO_BI_PARTNO

--- a/src/tracer_helper.c
+++ b/src/tracer_helper.c
@@ -54,7 +54,7 @@ bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio)
         if(unlikely(bio->bi_disk == NULL))
                 return false;
         sector_t offset;
-        if(dattobd_get_start_sect_by_gendisk(bio->bi_disk, bio->bi_partno, &offset)){
+        if(dattobd_get_start_sect_by_gendisk_for_bio(bio->bi_disk, bio->bi_partno, &offset)){
                 return false;
         }
         bio_sector_start += offset;

--- a/src/tracer_helper.c
+++ b/src/tracer_helper.c
@@ -31,7 +31,6 @@ bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio)
 {
         int active = 0;
         sector_t bio_sector_start = 0;
-        struct hd_struct* hd = NULL;
         if (!dev) {
                 return false;
         }

--- a/src/tracer_helper.c
+++ b/src/tracer_helper.c
@@ -47,7 +47,7 @@ bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio)
                 return false;
 
 #if defined HAVE_BIO_BI_BDEV
-        if(unlikely(bio->bdev == NULL))
+        if(unlikely(bio->bi_bdev == NULL))
                 return false;
         bio_sector_start += get_start_sect(bio->bi_bdev);
 #elif defined HAVE_BIO_BI_PARTNO

--- a/src/tracer_helper.c
+++ b/src/tracer_helper.c
@@ -53,11 +53,11 @@ bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio)
 #elif defined HAVE_BIO_BI_PARTNO
         if(unlikely(bio->bi_disk == NULL))
                 return false;
-        hd = disk_get_part(bio->bi_disk, bio->bi_partno);
-        if(unlikely(hd == NULL))
+        sector_t offset;
+        if(dattobd_get_start_sect_by_gendisk(bio->bi_disk, bio->bi_partno, &offset)){
                 return false;
-        bio_sector_start += hd->start_sect;
-        disk_put_part(hd);
+        }
+        bio_sector_start += offset;
 #else
         #error struct bio has neither bi_bdev nor bi_partno.
 #endif

--- a/src/tracer_helper.c
+++ b/src/tracer_helper.c
@@ -62,13 +62,9 @@ bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio)
         #error struct bio has neither bi_bdev nor bi_partno.
 #endif
 
-        if(likely(bio_sector_start >= dev->sd_sect_off && bio_sector_start + bio_sectors(bio) <= dev->sd_sect_off + dev->sd_size))
+        if(likely(bio_sector_start >= dev->sd_sect_off && bio_sector_start < dev->sd_sect_off + dev->sd_size))
                 return true;
         
-        if(likely(bio_sector_start >= dev->sd_sect_off + dev->sd_size || bio_sector_start + bio_sectors(bio) <= dev->sd_sect_off))
-                return false;
-        
-        LOG_WARN("bio and snap_device have intersecting sector range! this may cause the corruption! bio: start=%llu size=%u; snap_device: start=%llu size=%llu", bio_sector_start, bio_sectors(bio), dev->sd_sect_off, dev->sd_size);
         return false;
 }
 

--- a/src/tracer_helper.c
+++ b/src/tracer_helper.c
@@ -10,6 +10,7 @@
 #include "includes.h"
 #include "snap_device.h"
 #include "logging.h"
+#include "blkdev.h"
 
 
 int tracer_read_fail_state(const struct snap_device *dev)

--- a/src/tracer_helper.c
+++ b/src/tracer_helper.c
@@ -47,7 +47,7 @@ bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio)
                 return false;
 
 #if defined HAVE_BIO_BI_BDEV
-        if(unlikely(bi->bdev == NULL))
+        if(unlikely(bio->bdev == NULL))
                 return false;
         bio_sector_start += get_start_sect(bio->bi_bdev);
 #elif defined HAVE_BIO_BI_PARTNO

--- a/src/tracer_helper.c
+++ b/src/tracer_helper.c
@@ -47,9 +47,7 @@ bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio)
                 return false;
 
 #if defined HAVE_BIO_BI_BDEV
-        if(unlikely(bio->bi_bdev == NULL))
-                return false;
-        bio_sector_start += get_start_sect(bio->bi_bdev);
+        // assuming that bio was already partitioned by kernel.
 #elif defined HAVE_BIO_BI_PARTNO
         if(unlikely(bio->bi_disk == NULL))
                 return false;

--- a/src/tracer_helper.h
+++ b/src/tracer_helper.h
@@ -48,6 +48,19 @@
 bool tracer_is_bio_for_dev(struct snap_device *dev, struct bio *bio);
 
 /**
+ * tracer_is_bio_for_dev_only_queue() - Check if bio is intended for given snap_device.
+ *
+ * returns true if bio's queue matches the devices' queue
+ *
+ * @dev: The snap_device to check the bio against.
+ * @bio: The bio to check the snap device against.
+ *
+ * Return: True if bio is for devs queue originally. 
+ *         False otherwise.
+ */
+bool tracer_is_bio_for_dev_only_queue(struct snap_device *dev, struct bio *bio);
+
+/**
  * tracer_should_trace_bio() - Check if given bio should be traced.
  *
  * Return: Returns true if dev is not null


### PR DESCRIPTION
This PR involves a bunch of fixes along with version bump to 0.11.8.

What was changed:
 - [🔧] Fixed compile errors on newer kernels (RPMs Kernels 5.14.0-427.16+)
 - [🔧] Fixed kernel panic on module unload on systems based on kernels of version 5.0+
 - [🔧] Fixed kernel panic on module unload on RHEL8-based systems
 - [🔧] Fixed kernel oops on module unload on Ubuntu 20.04 LTS
 - [🔧] Fixed problems related to tracking BIOs on systems with multiple block devices on the same general disk 