### PR TITLE
DattoBD 0.11.8.1 Hotfix

### DIFF
--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -611,6 +611,9 @@ rm %{_systemd_shutdown}/umount_rootfs.shutdown
 rm %{_systemd_services}/umount-rootfs.service
 
 %changelog
+* Tue Sep 24 2024 Andrii Fylypiuk <andrii.fylypiuk@datto.com> - 0.11.8.1
+- Fixed panic on mount of snapshot device on RHEL 8.10 and systems with the same kernel
+
 * Mon Sep 09 2024 Andrii Fylypiuk <andrii.fylypiuk@datto.com> - 0.11.8
 - Fixed compile errors on newer kernels (RPMs Kernels 5.14.0-427.16+)
 - Fixed kernel panic on module unload on systems based on kernels of version 5.0+

--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -117,7 +117,7 @@
 
 
 Name:            dattobd
-Version:         0.11.8
+Version:         0.11.8.1
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Datto, Inc.

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -15,7 +15,7 @@
 #include <linux/limits.h>
 #include <linux/types.h>
 
-#define DATTOBD_VERSION "0.11.8"
+#define DATTOBD_VERSION "0.11.8.1"
 #define DATTO_IOCTL_MAGIC 0x91
 
 struct setup_params {

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1056,11 +1056,11 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor,
         LOG_DEBUG("allocating queue");
 #if defined HAVE_MAKE_REQUEST_FN_IN_QUEUE && !defined HAVE_BLK_ALLOC_QUEUE_RH_2
         dev->sd_queue = blk_alloc_queue(GFP_KERNEL);
+#elif defined HAVE_BLK_ALLOC_QUEUE_RH_2 // el8
+        dev->sd_queue = blk_alloc_queue_rh(snap_mrf, NUMA_NO_NODE);
 #elif defined HAVE_BLK_ALLOC_QUEUE_1
         // #if LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0)
         dev->sd_queue = blk_alloc_queue(GFP_KERNEL);
-#elif defined HAVE_BLK_ALLOC_QUEUE_RH_2 // el8
-        dev->sd_queue = blk_alloc_queue_rh(snap_mrf, NUMA_NO_NODE);
 #elif defined HAVE_BLK_ALLOC_QUEUE_2
         dev->sd_queue = blk_alloc_queue(snap_mrf, NUMA_NO_NODE);
 #elif !defined HAVE_BLK_ALLOC_DISK


### PR DESCRIPTION
This PR involves a fixes of panic on RHEL8-based systems along with version bump to 0.11.8.1.

What was changed:

 - [🔧] Fixed panic on mount of `/dev/dattoX` device on RHEL 8.10 and systems with the same kernel.