### PR TITLE
DattoBD 0.11.9 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ The current status of the dattobd driver can be read from the file `/proc/datto-
 * `cow_size_current`: The current size of the cow file (in bytes). This will not be printed if the device is in the unverified state.
 * `seq_id`: The sequence id of the snapshot. This number starts at 1 for new snapshots and is incremented on each transition to snapshot.
 * `uuid`: Uniquely identifies a series of snapshots. It is not changed on state transition.
+* `auto_expand`: Parameters of auto-expansion of COW-file.
+    * `step_size`: Expansion step size (in bytes)
+    * `steps`: Steps the DattoBD allowed to do (-1 if unlimited).
 * `error`: This field will only be present if the device has failed. It shows the linux standard error code indicating what went wrong. More specific info is printed to dmesg.
 * `state`: An integer representing the current working state of the device. There are 6 possible states; for more info on these refer to [STRUCTURE.md](doc/STRUCTURE.md).
 	* 0 = dormant incremental

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The current status of the dattobd driver can be read from the file `/proc/datto-
 * `block_device`: The block device being tracked by this device.
 * `max_cache`: The maximum amount of memory that may be used to cache metadata for this device (in bytes).
 * `fallocate`: The preallocated size of the cow file (in bytes). This will not be printed if the device is in the unverified state.
+* `cow_size_current`: The current size of the cow file (in bytes). This will not be printed if the device is in the unverified state.
 * `seq_id`: The sequence id of the snapshot. This number starts at 1 for new snapshots and is incremented on each transition to snapshot.
 * `uuid`: Uniquely identifies a series of snapshots. It is not changed on state transition.
 * `error`: This field will only be present if the device has failed. It shows the linux standard error code indicating what went wrong. More specific info is printed to dmesg.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ The current status of the dattobd driver can be read from the file `/proc/datto-
 * `seq_id`: The sequence id of the snapshot. This number starts at 1 for new snapshots and is incremented on each transition to snapshot.
 * `uuid`: Uniquely identifies a series of snapshots. It is not changed on state transition.
 * `auto_expand`: Parameters of auto-expansion of COW-file.
-    * `step_size`: Expansion step size (in bytes)
-    * `steps`: Steps the DattoBD allowed to do (-1 if unlimited).
+    * `step_size_mib`: Expansion step size (in megabytes).
+    * `reserved_space_mib`: Space that has to be left available for users during auto-expand process (in megabytes).
 * `error`: This field will only be present if the device has failed. It shows the linux standard error code indicating what went wrong. More specific info is printed to dmesg.
 * `state`: An integer representing the current working state of the device. There are 6 possible states; for more info on these refer to [STRUCTURE.md](doc/STRUCTURE.md).
 	* 0 = dormant incremental

--- a/app/bash_completion.d/dbdctl
+++ b/app/bash_completion.d/dbdctl
@@ -4,7 +4,7 @@ _dbdctl()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="setup-snapshot reload-snapshot reload-incremental destroy transition-to-incremental transition-to-snapshot reconfigure expand-cow-file help"
+    opts="setup-snapshot reload-snapshot reload-incremental destroy transition-to-incremental transition-to-snapshot reconfigure expand-cow-file reconfigure-auto-expand help"
 
     if [[ ${cur} == * ]] ; then
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )

--- a/app/bash_completion.d/dbdctl
+++ b/app/bash_completion.d/dbdctl
@@ -4,7 +4,7 @@ _dbdctl()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="setup-snapshot reload-snapshot reload-incremental destroy transition-to-incremental transition-to-snapshot reconfigure help"
+    opts="setup-snapshot reload-snapshot reload-incremental destroy transition-to-incremental transition-to-snapshot reconfigure expand-cow-file help"
 
     if [[ ${cur} == * ]] ; then
         COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )

--- a/app/dbdctl.c
+++ b/app/dbdctl.c
@@ -23,6 +23,7 @@ static void print_help(int status){
 	printf("\tdbdctl transition-to-incremental <minor>\n");
 	printf("\tdbdctl transition-to-snapshot [-f fallocate] <cow file> <minor>\n");
 	printf("\tdbdctl reconfigure [-c <cache size>] <minor>\n");
+	printf("\tdbdctl expand-cow-file <minor> <size>\n");
 	printf("\tdbdctl help\n\n");
 	printf("<cow file> should be specified as an absolute path.\n");
 	printf("cache size should be provided in bytes, and fallocate should be provided in megabytes.\n");
@@ -315,6 +316,30 @@ error:
 	return 0;
 }
 
+static int handle_expand_cow_file(int argc, char **argv){
+	int ret;
+	unsigned int minor;
+	unsigned long size;
+
+	if(argc != 3){
+		errno = EINVAL;
+		goto error;
+	}
+
+	ret = parse_ui(argv[1], &minor);
+	if(ret) goto error;
+
+	ret = parse_ul(argv[2], &size);
+	if(ret) goto error;
+
+	return dattobd_expand_cow_file(minor, size);
+
+error:
+	perror("error interpreting expand parameters");
+	print_help(-1);
+	return 0;
+}
+
 int main(int argc, char **argv){
 	int ret = 0;
 
@@ -335,6 +360,7 @@ int main(int argc, char **argv){
 	else if(!strcmp(argv[1], "transition-to-incremental")) ret = handle_transition_inc(argc - 1, argv + 1);
 	else if(!strcmp(argv[1], "transition-to-snapshot")) ret = handle_transition_snap(argc - 1, argv + 1);
 	else if(!strcmp(argv[1], "reconfigure")) ret = handle_reconfigure(argc - 1, argv + 1);
+	else if(!strcmp(argv[1], "expand-cow-file")) ret = handle_expand_cow_file(argc - 1, argv + 1);
 	else if(!strcmp(argv[1], "help")) print_help(0);
 	else print_help(-1);
 

--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -117,7 +117,7 @@
 
 
 Name:            dattobd
-Version:         0.11.8.1
+Version:         0.11.9
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Datto, Inc.

--- a/doc/dbdctl.8
+++ b/doc/dbdctl.8
@@ -75,16 +75,16 @@ Cleanly and completely removes the snapshot or incremental, unlinking the associ
 Allows you to reconfigure various parameters of a snapshot while it is online\. Currently only the index cache size (given in MB) can be changed dynamically\.
 .
 .SS "expand-cow-file"
-\fBdbdctl expand-cow-file <minor> <size>\fR
+\fBdbdctl expand-cow-file <size> <minor>\fR
 .
 .P
-Expands cow file in snapshot mode by size (given in bytes)\.
+Expands cow file in snapshot mode by size (given in megabytes)\.
 .
 .SS "reconfigure-auto-expand"
-\fBdbdctl reconfigure-auto-expand [-n <steps limit>] <step size> <minor>\fR
+\fBdbdctl reconfigure-auto-expand [-r <reserved space>] <step size> <minor>\fR
 .
 .P
-Enable auto-expand of cow file in snapshot mode by <step size> (given in bytes), limited with <steps limit> steps (or -1 if unlimited)\.
+Enable auto-expand of cow file in snapshot mode by <step size> (given in megabytes). Auto-expand works in that way that at least <reserved space> (given in megabytes) is left available after each step for regular users of filesystem\.
 .
 .SS "EXAMPLES"
 \fB# dbdctl setup\-snapshot /dev/sda1 /var/backup/datto 4\fR

--- a/doc/dbdctl.8
+++ b/doc/dbdctl.8
@@ -74,6 +74,12 @@ Cleanly and completely removes the snapshot or incremental, unlinking the associ
 .P
 Allows you to reconfigure various parameters of a snapshot while it is online\. Currently only the index cache size (given in MB) can be changed dynamically\.
 .
+.SS "expand-cow-file"
+\fBdbdctl expand-cow-file <minor> <size>\fR
+.
+.P
+Expands cow file in snapshot mode by size (given in bytes)\.
+.
 .SS "EXAMPLES"
 \fB# dbdctl setup\-snapshot /dev/sda1 /var/backup/datto 4\fR
 .

--- a/doc/dbdctl.8
+++ b/doc/dbdctl.8
@@ -80,6 +80,12 @@ Allows you to reconfigure various parameters of a snapshot while it is online\. 
 .P
 Expands cow file in snapshot mode by size (given in bytes)\.
 .
+.SS "reconfigure-auto-expand"
+\fBdbdctl reconfigure-auto-expand [-n <steps limit>] <step size> <minor>\fR
+.
+.P
+Enable auto-expand of cow file in snapshot mode by <step size> (given in bytes), limited with <steps limit> steps (or -1 if unlimited)\.
+.
 .SS "EXAMPLES"
 \fB# dbdctl setup\-snapshot /dev/sda1 /var/backup/datto 4\fR
 .

--- a/doc/dbdctl.8.html
+++ b/doc/dbdctl.8.html
@@ -140,6 +140,12 @@
 
 <p>Allows you to reconfigure various parameters of a snapshot while it is online. Currently only the index cache size (given in MB) can be changed dynamically.</p>
 
+<h3 id="expand-cow-file">expand-cow-file</h3>
+
+<p><code>dbdctl expand-cow-file &lt;minor&gt; &lt;size&gt;</code></p>
+
+<p>Expands cow file in snapshot mode by size (given in bytes).</p>
+
 <h3 id="EXAMPLES">EXAMPLES</h3>
 
 <p><code># dbdctl setup-snapshot /dev/sda1 /var/backup/datto 4</code></p>

--- a/doc/dbdctl.8.html
+++ b/doc/dbdctl.8.html
@@ -146,6 +146,12 @@
 
 <p>Expands cow file in snapshot mode by size (given in bytes).</p>
 
+<h3 id="reconfigure-auto-expand">reconfigure-auto-expand</h3>
+
+<p><code>dbdctl reconfigure-auto-expand [-n &lt;steps limit&gt;] &lt;step size&gt; &lt;minor&gt;</code></p>
+
+<p>Enable auto-expand of cow file in snapshot mode by &lt;step size&gt; (given in bytes), limited with &lt;steps limit&gt; steps (or -1 if unlimited).</p>
+
 <h3 id="EXAMPLES">EXAMPLES</h3>
 
 <p><code># dbdctl setup-snapshot /dev/sda1 /var/backup/datto 4</code></p>

--- a/doc/dbdctl.8.html
+++ b/doc/dbdctl.8.html
@@ -142,15 +142,15 @@
 
 <h3 id="expand-cow-file">expand-cow-file</h3>
 
-<p><code>dbdctl expand-cow-file &lt;minor&gt; &lt;size&gt;</code></p>
+<p><code>dbdctl expand-cow-file &lt;size&gt; &lt;minor&gt;</code></p>
 
-<p>Expands cow file in snapshot mode by size (given in bytes).</p>
+<p>Expands cow file in snapshot mode by size (given in megabytes).</p>
 
 <h3 id="reconfigure-auto-expand">reconfigure-auto-expand</h3>
 
-<p><code>dbdctl reconfigure-auto-expand [-n &lt;steps limit&gt;] &lt;step size&gt; &lt;minor&gt;</code></p>
+<p><code>dbdctl reconfigure-auto-expand [-r &lt;reserved space&gt;] &lt;step size&gt; &lt;minor&gt;</code></p>
 
-<p>Enable auto-expand of cow file in snapshot mode by &lt;step size&gt; (given in bytes), limited with &lt;steps limit&gt; steps (or -1 if unlimited).</p>
+<p>Enable auto-expand of cow file in snapshot mode by &lt;step size&gt; (given in megabytes). Auto-expand works in that way that at least &lt;reserved space&gt; (given in megabytes) is left available after each step for regular users of filesystem.</p>
 
 <h3 id="EXAMPLES">EXAMPLES</h3>
 

--- a/doc/dbdctl.8.md
+++ b/doc/dbdctl.8.md
@@ -69,6 +69,12 @@ Allows you to reconfigure various parameters of a snapshot while it is online. C
 
 Expands cow file in snapshot mode by size (given in bytes).
 
+### reconfigure-auto-expand
+
+`dbdctl reconfigure-auto-expand [-n <steps limit>] <step size> <minor>`
+
+Enable auto-expand of cow file in snapshot mode by <step size> (given in bytes), limited with <steps limit> steps (or -1 if unlimited).
+
 ### EXAMPLES
 
 `# dbdctl setup-snapshot /dev/sda1 /var/backup/datto 4`

--- a/doc/dbdctl.8.md
+++ b/doc/dbdctl.8.md
@@ -63,6 +63,12 @@ Cleanly and completely removes the snapshot or incremental, unlinking the associ
 
 Allows you to reconfigure various parameters of a snapshot while it is online. Currently only the index cache size (given in MB) can be changed dynamically.
 
+### expand-cow-file
+
+`dbdctl expand-cow-file <minor> <size>`
+
+Expands cow file in snapshot mode by size (given in bytes).
+
 ### EXAMPLES
 
 `# dbdctl setup-snapshot /dev/sda1 /var/backup/datto 4`

--- a/doc/dbdctl.8.md
+++ b/doc/dbdctl.8.md
@@ -65,15 +65,15 @@ Allows you to reconfigure various parameters of a snapshot while it is online. C
 
 ### expand-cow-file
 
-`dbdctl expand-cow-file <minor> <size>`
+`dbdctl expand-cow-file <size> <minor>`
 
-Expands cow file in snapshot mode by size (given in bytes).
+Expands cow file in snapshot mode by size (given in megabytes).
 
 ### reconfigure-auto-expand
 
 `dbdctl reconfigure-auto-expand [-n <steps limit>] <step size> <minor>`
 
-Enable auto-expand of cow file in snapshot mode by <step size> (given in bytes), limited with <steps limit> steps (or -1 if unlimited).
+Enable auto-expand of cow file in snapshot mode by <step size> (given in megabytes). Auto-expand works in that way that at least <reserved space> (given in megabytes) is left available after each step for regular users of filesystem.
 
 ### EXAMPLES
 

--- a/lib/libdattobd.c
+++ b/lib/libdattobd.c
@@ -169,3 +169,19 @@ int dattobd_expand_cow_file(unsigned int minor, unsigned long size){
 	close(fd);
 	return ret;
 }
+
+int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, long steps){
+	int fd, ret;
+	struct reconfigure_auto_expand_params params;
+	params.minor=minor;
+	params.step_size=step_size;
+	params.steps=steps;
+
+	fd = open("/dev/datto-ctl", O_RDONLY);
+	if(fd < 0) return -1;
+
+	ret = ioctl(fd, IOCTL_RECONFIGURE_AUTO_EXPAND, &params);
+
+	close(fd);
+	return ret;
+}

--- a/lib/libdattobd.c
+++ b/lib/libdattobd.c
@@ -155,11 +155,12 @@ int dattobd_get_free_minor(void){
 	return ret;
 }
 
-int dattobd_expand_cow_file(unsigned int minor, unsigned long size){
+int dattobd_expand_cow_file(unsigned int minor, uint64_t size){
 	int fd, ret;
-	struct expand_cow_file_params params;
-	params.minor=minor;
-	params.size=size;
+	struct expand_cow_file_params params = {
+		.size = size,
+		.minor = minor
+	};
 
 	fd = open("/dev/datto-ctl", O_RDONLY);
 	if(fd < 0) return -1;
@@ -170,12 +171,13 @@ int dattobd_expand_cow_file(unsigned int minor, unsigned long size){
 	return ret;
 }
 
-int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, long steps){
+int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, uint64_t reserved_space){
 	int fd, ret;
-	struct reconfigure_auto_expand_params params;
-	params.minor=minor;
-	params.step_size=step_size;
-	params.steps=steps;
+	struct reconfigure_auto_expand_params params = {
+		.step_size = step_size,
+		.reserved_space = reserved_space,
+		.minor = minor
+	};
 
 	fd = open("/dev/datto-ctl", O_RDONLY);
 	if(fd < 0) return -1;

--- a/lib/libdattobd.c
+++ b/lib/libdattobd.c
@@ -154,3 +154,18 @@ int dattobd_get_free_minor(void){
 	if(!ret) return minor;
 	return ret;
 }
+
+int dattobd_expand_cow_file(unsigned int minor, unsigned long size){
+	int fd, ret;
+	struct expand_cow_file_params params;
+	params.minor=minor;
+	params.size=size;
+
+	fd = open("/dev/datto-ctl", O_RDONLY);
+	if(fd < 0) return -1;
+
+	ret = ioctl(fd, IOCTL_EXPAND_COW_FILE, &params);
+
+	close(fd);
+	return ret;
+}

--- a/lib/libdattobd.h
+++ b/lib/libdattobd.h
@@ -31,6 +31,8 @@ int dattobd_info(unsigned int minor, struct dattobd_info *info);
 
 int dattobd_expand_cow_file(unsigned int minor, unsigned long size);
 
+int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, long steps);
+
 /**
  * Get the first available minor.
  *

--- a/lib/libdattobd.h
+++ b/lib/libdattobd.h
@@ -29,9 +29,9 @@ int dattobd_reconfigure(unsigned int minor, unsigned long cache_size);
 
 int dattobd_info(unsigned int minor, struct dattobd_info *info);
 
-int dattobd_expand_cow_file(unsigned int minor, unsigned long size);
+int dattobd_expand_cow_file(unsigned int minor, uint64_t size);
 
-int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, long steps);
+int dattobd_reconfigure_auto_expand(unsigned int minor, uint64_t step_size, uint64_t reserved_space);
 
 /**
  * Get the first available minor.

--- a/lib/libdattobd.h
+++ b/lib/libdattobd.h
@@ -29,6 +29,8 @@ int dattobd_reconfigure(unsigned int minor, unsigned long cache_size);
 
 int dattobd_info(unsigned int minor, struct dattobd_info *info);
 
+int dattobd_expand_cow_file(unsigned int minor, unsigned long size);
+
 /**
  * Get the first available minor.
  *

--- a/src/bdev_state_handler.c
+++ b/src/bdev_state_handler.c
@@ -68,7 +68,7 @@ int __handle_bdev_mount_nowrite(const struct vfsmount *mnt,
                     dev->sd_base_dev != mnt->mnt_sb->s_bdev)
                         continue;
 
-                if (mnt == dattobd_get_mnt(dev->sd_cow->filp)) {
+                if (mnt == dev->sd_cow->dfilp->mnt) {
                         LOG_DEBUG("block device umount detected for device %d",
                                   i);
                         auto_transition_dormant(i);

--- a/src/blkdev.h
+++ b/src/blkdev.h
@@ -37,4 +37,6 @@ void dattobd_drop_super(struct super_block *sb);
 void dattobd_blkdev_put(struct block_device *bd);
 
 int dattobd_get_start_sect_by_gendisk_for_bio(struct gendisk* gd, u8 partno, sector_t* result);
+
+int dattobd_get_kstatfs(struct block_device* bd, struct kstatfs* statfs);
 #endif /* BLKDEV_H_ */

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -26,6 +26,34 @@
 #define get_zeroed_pages(flags, order)                                         \
         __get_free_pages(((flags) | __GFP_ZERO), order)
 
+inline void __close_and_destroy_dattobd_mutable_file(struct dattobd_mutable_file *dfilp){
+        file_close(dfilp);
+        dattobd_mutable_file_unwrap(dfilp);
+}
+
+inline int __open_dattobd_mutable_file(const char *path, int flags, struct dattobd_mutable_file **dfilp){
+        struct file* filp = NULL;
+        int ret;
+
+        ret = file_open(path, flags, &filp);
+
+        if(ret){
+                LOG_ERROR(ret, "failed to open file");
+                return ret;
+        }
+
+        *dfilp = dattobd_mutable_file_wrap(filp);
+
+        if(IS_ERR(*dfilp)){
+                LOG_ERROR(-ENOMEM, "failed to wrap file pointer");
+                __file_close_raw(filp);
+                // filp does not need to be kfreed here, it is handled by the filp_close under the hood
+                return -ENOMEM;
+        }
+
+        return 0;
+}
+
 /**
  * __cow_free_section() - Frees the memory used to track the section at
  * offset @sect_idx and marks the array entry as unused.
@@ -99,11 +127,11 @@ int __cow_load_section(struct cow_manager *cm, unsigned long sect_idx)
 		int mapping_offset = (COW_BLOCK_SIZE / sizeof(cm->sects[sect_idx].mappings[0])) * i;
 		int cow_file_offset = COW_BLOCK_SIZE * i;
 
-        ret = file_read(cm->filp, cm->dev, cm->sects[sect_idx].mappings,
-                        cm->sect_size * sect_idx * 8 + COW_HEADER_SIZE,
-                        cm->sect_size * 8);
-        if (ret)
-                goto error;
+                ret = file_read(cm->dfilp, cm->dev, cm->sects[sect_idx].mappings,
+                                cm->sect_size * sect_idx * 8 + COW_HEADER_SIZE,
+                                cm->sect_size * 8);
+                if (ret)
+                        goto error;
         }
 
         return 0;
@@ -133,7 +161,7 @@ int __cow_write_section(struct cow_manager *cm, unsigned long sect_idx)
 		int mapping_offset = (COW_BLOCK_SIZE / sizeof(cm->sects[sect_idx].mappings[0])) * i;
 		int cow_file_offset = COW_BLOCK_SIZE * i;
 
-        ret = file_write(cm->filp, cm->dev, cm->sects[sect_idx].mappings,
+        ret = file_write(cm->dfilp, cm->dev, cm->sects[sect_idx].mappings,
                          cm->sect_size * sect_idx * 8 + COW_HEADER_SIZE,
                          cm->sect_size * 8);
         if (ret) {
@@ -271,13 +299,13 @@ int __cow_write_header(struct cow_manager *cm, int is_clean)
         ch.magic = COW_MAGIC;
         ch.flags = cm->flags;
         ch.fpos = cm->curr_pos;
-        ch.fsize = cm->file_max;
+        ch.fsize = cm->file_size;
         ch.seqid = cm->seqid;
         memcpy(ch.uuid, cm->uuid, COW_UUID_SIZE);
         ch.version = cm->version;
         ch.nr_changed_blocks = cm->nr_changed_blocks;
 
-        ret = file_write(cm->filp, cm->dev, &ch, 0, sizeof(struct cow_header));
+        ret = file_write(cm->dfilp, cm->dev, &ch, 0, sizeof(struct cow_header));
         if (ret) {
                 LOG_ERROR(ret, "error syncing cow manager header");
                 return ret;
@@ -309,7 +337,7 @@ int __cow_open_header(struct cow_manager *cm, int index_only, int reset_vmalloc)
         int ret;
         struct cow_header ch;
 
-        ret = file_read(cm->filp, cm->dev, &ch, 0, sizeof(struct cow_header));
+        ret = file_read(cm->dfilp, cm->dev, &ch, 0, sizeof(struct cow_header));
         if (ret)
                 goto error;
 
@@ -345,7 +373,7 @@ int __cow_open_header(struct cow_manager *cm, int index_only, int reset_vmalloc)
                 cm->flags = ch.flags;
 
         cm->curr_pos = ch.fpos;
-        cm->file_max = ch.fsize;
+        cm->file_size = ch.fsize;
         cm->seqid = ch.seqid;
         memcpy(cm->uuid, ch.uuid, COW_UUID_SIZE);
         cm->version = ch.version;
@@ -386,9 +414,10 @@ void cow_free_members(struct cow_manager *cm)
                 cm->sects = NULL;
         }
 
-        if (cm->filp) {
-                file_unlink_and_close_force(cm->filp);
-                cm->filp = NULL;
+        if (cm->dfilp) {
+                file_unlink_and_close_force(cm->dfilp);
+                __close_and_destroy_dattobd_mutable_file(cm->dfilp);
+                cm->dfilp = NULL;
         }
 }
 
@@ -426,9 +455,10 @@ int cow_sync_and_free(struct cow_manager *cm)
         if (ret)
                 goto error;
 
-        if (cm->filp)
-                file_close(cm->filp);
-        cm->filp = NULL;
+        if (cm->dfilp){
+                __close_and_destroy_dattobd_mutable_file(cm->dfilp);
+                cm->dfilp = NULL;
+        }
 
         if (cm->sects) {
                 if (cm->flags & (1 << COW_VMALLOC_UPPER))
@@ -470,12 +500,13 @@ int cow_sync_and_close(struct cow_manager *cm)
         if (ret)
                 goto error;
 
-        ret = cow_get_file_extents(cm->dev, cm->filp);
+        ret = cow_get_file_extents(cm->dev, cm->dfilp->filp);
 	if(ret) goto error;
 
-        if (cm->filp)
-                file_close(cm->filp);
-        cm->filp = NULL;
+        if (cm->dfilp){
+                __close_and_destroy_dattobd_mutable_file(cm->dfilp);
+                cm->dfilp = NULL;
+        }
 
         return 0;
 
@@ -500,7 +531,7 @@ int cow_reopen(struct cow_manager *cm, const char *pathname)
         int ret;
 
         LOG_DEBUG("reopening cow file");
-        ret = file_open(pathname, 0, &cm->filp);
+        ret = __open_dattobd_mutable_file(pathname, 0, &cm->dfilp);
         if (ret)
                 goto error;
 
@@ -513,9 +544,10 @@ int cow_reopen(struct cow_manager *cm, const char *pathname)
 
 error:
         LOG_ERROR(ret, "error reopening cow manager");
-        if (cm->filp)
-                file_close(cm->filp);
-        cm->filp = NULL;
+        if (cm->dfilp){
+                __close_and_destroy_dattobd_mutable_file(cm->dfilp);
+                cm->dfilp = NULL;
+        }
 
         return ret;
 }
@@ -578,7 +610,7 @@ int cow_reload(const char *path, uint64_t elements, unsigned long sect_size,
         }
 
         LOG_DEBUG("opening cow file");
-        ret = file_open(path, 0, &cm->filp);
+        ret = __open_dattobd_mutable_file(path, 0, &cm->dfilp);
         if (ret)
                 goto error;
 
@@ -621,8 +653,10 @@ int cow_reload(const char *path, uint64_t elements, unsigned long sect_size,
 
 error:
         LOG_ERROR(ret, "error during cow manager initialization");
-        if (cm->filp)
-                file_close(cm->filp);
+        if (cm->dfilp){
+                __close_and_destroy_dattobd_mutable_file(cm->dfilp);
+                cm->dfilp = NULL;
+        }
 
         if (cm->sects) {
                 if (cm->flags & (1 << COW_VMALLOC_UPPER))
@@ -674,7 +708,7 @@ int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsig
         }
 
         LOG_DEBUG("creating cow file");
-        ret = file_open(path, O_CREAT | O_TRUNC, &cm->filp);
+        ret = __open_dattobd_mutable_file(path, O_CREAT | O_TRUNC, &cm->dfilp);
         if (ret)
                 goto error;
 
@@ -682,15 +716,18 @@ int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsig
         cm->nr_changed_blocks = 0;
         cm->flags = 0;
         cm->allocated_sects = 0;
-        cm->file_max = file_max;
-        cm->sect_size = sect_size;
+        cm->file_size = file_max;
+        cm->sect_size = sect_size; //how many elements(sectors) can section hold (in datastore); = 4096
         cm->seqid = seqid;
-        cm->log_sect_pages = get_order(sect_size * 8);
+        // get_order(x) = ceil[log2(x / PAGE_SIZE)]
+        cm->log_sect_pages = get_order(sect_size * 8); //PAGE_SIZE = 4096 bytes; log2[pages in section in index]; = log2(4096*8/4096) = 3
+        // this implies that section uses 2^15 B in index => sector consists of 8 B of metadata in index
+        // means how many pages do we need to store metadata of one section in index
         cm->total_sects =
-                NUM_SEGMENTS(elements, cm->log_sect_pages + PAGE_SHIFT - 3);
+                NUM_SEGMENTS(elements, cm->log_sect_pages + PAGE_SHIFT - 3);  //total sections to store all of the sectors; = ceil(elements / 4096)
         cm->allowed_sects =
-                __cow_calculate_allowed_sects(cache_size, cm->total_sects);
-        cm->data_offset = COW_HEADER_SIZE + (cm->total_sects * (sect_size * 8));
+                __cow_calculate_allowed_sects(cache_size, cm->total_sects); //num of sections that can fit in cache apart from index
+        cm->data_offset = COW_HEADER_SIZE + (cm->total_sects * (sect_size * 8)); // data offset in bytes, equals 4096 + [total_sects*4096*8](index size)
         cm->curr_pos = cm->data_offset / COW_BLOCK_SIZE;
         cm->dev = dev;
 
@@ -718,7 +755,7 @@ int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsig
 
         LOG_DEBUG("allocating cow file (%llu bytes)",
                   (unsigned long long)file_max);
-        ret = file_allocate(cm->filp, cm->dev, 0, file_max);
+        ret = file_allocate(cm->dfilp, cm->dev, 0, file_max, NULL);
         if (ret)
                 goto error;
 
@@ -731,8 +768,11 @@ int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsig
 
 error:
         LOG_ERROR(ret, "error during cow manager initialization");
-        if (cm->filp)
-                file_unlink_and_close(cm->filp);
+        if (cm->dfilp){
+                file_unlink_and_close(cm->dfilp);
+                __close_and_destroy_dattobd_mutable_file(cm->dfilp);
+                cm->dfilp = NULL;
+        }
 
         if (cm->sects) {
                 if (cm->flags & (1 << COW_VMALLOC_UPPER))
@@ -760,9 +800,16 @@ error:
  */
 int cow_truncate_to_index(struct cow_manager *cm)
 {
+        int ret;
+
         // truncate the cow file to just the index
         cm->flags |= (1 << COW_INDEX_ONLY);
-        return file_truncate(cm->filp, cm->data_offset);
+        ret = file_truncate(cm->dfilp, cm->data_offset);
+
+        if(!ret)
+                cm->file_size = cm->data_offset;
+        
+        return ret;
 }
 
 /**
@@ -844,6 +891,7 @@ int __cow_write_mapping(struct cow_manager *cm, uint64_t pos, uint64_t val)
         int ret;
         uint64_t sect_idx = pos;
         unsigned long sect_pos = do_div(sect_idx, cm->sect_size);
+        //do_div modifies sect_idx to be the quotient of pos divided by cm->sect_size and returns the remainder
 
         cm->sects[sect_idx].usage++;
 
@@ -896,24 +944,24 @@ static int __cow_write_data(struct cow_manager *cm, void *buf)
         int abs_path_len;
         uint64_t curr_size = cm->curr_pos * COW_BLOCK_SIZE;
 
-        if (curr_size >= cm->file_max) {
+        if (curr_size >= cm->file_size) {
                 ret = -EFBIG;
 
-                file_get_absolute_pathname(cm->filp, &abs_path, &abs_path_len);
+                file_get_absolute_pathname(cm->dfilp, &abs_path, &abs_path_len);
                 if (!abs_path) {
                         LOG_ERROR(ret, "cow file max size exceeded (%llu/%llu)",
-                                  curr_size, cm->file_max);
+                                  curr_size, cm->file_size);
                 } else {
                         LOG_ERROR(ret,
                                   "cow file '%s' max size exceeded (%llu/%llu)",
-                                  abs_path, curr_size, cm->file_max);
+                                  abs_path, curr_size, cm->file_size);
                         kfree(abs_path);
                 }
 
                 goto error;
         }
 
-        ret = file_write(cm->filp, cm->dev, buf, curr_size, COW_BLOCK_SIZE);
+        ret = file_write(cm->dfilp, cm->dev, buf, curr_size, COW_BLOCK_SIZE);
         if (ret)
                 goto error;
 
@@ -992,7 +1040,7 @@ int cow_read_data(struct cow_manager *cm, void *buf, uint64_t block_pos,
         if (block_off >= COW_BLOCK_SIZE)
                 return -EINVAL;
 
-        ret = file_read(cm->filp, cm->dev, buf, (block_pos * COW_BLOCK_SIZE) + block_off,
+        ret = file_read(cm->dfilp, cm->dev, buf, (block_pos * COW_BLOCK_SIZE) + block_off,
                         len);
         if (ret) {
                 LOG_ERROR(ret, "error reading cow data");
@@ -1134,4 +1182,25 @@ out:
 	vm_munmap(vma->vm_start, cow_ext_buf_size);
 	__free_pages(pg, get_order(cow_ext_buf_size));
 	return ret;
+}
+
+
+int __cow_expand_datastore(struct cow_manager* cm, uint64_t append_size){
+        int ret;
+        uint64_t actual = 0;
+
+        ret = file_allocate(cm->dfilp, cm->dev, cm->file_size, append_size, &actual);
+
+        if(actual != append_size){
+                LOG_WARN("cow file was not expanded to requested size (req: %llu, act: %llu)", append_size, actual);
+        }
+
+        cm->file_size = cm->file_size + actual;
+
+        if (ret){
+                LOG_ERROR(ret, "unable to expand cow file");
+                return ret;
+        }
+
+        return 0;
 }

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -41,11 +41,11 @@ struct cow_section {
 };
 
 struct cow_manager {
-        struct file *filp; // the file the cow manager is writing to
+        struct dattobd_mutable_file *dfilp; // the file the cow manager is writing to
         uint32_t flags; // flags representing current state of cow manager
         uint64_t curr_pos; // current write head position
         uint64_t data_offset; // starting offset of data
-        uint64_t file_max; // max size of the file before an error is thrown
+        uint64_t file_size; // current size of the file, max size before an error is thrown
         uint64_t seqid; // sequence id, increments on each transition to
                         // snapshot mode
         uint64_t version; // version of cow file format
@@ -99,5 +99,7 @@ int cow_read_data(struct cow_manager *cm, void *buf, uint64_t block_pos,
 int __cow_write_mapping(struct cow_manager *cm, uint64_t pos, uint64_t val);
 
 int cow_get_file_extents(struct snap_device* dev, struct file* filp);
+
+int __cow_expand_datastore(struct cow_manager *cm, uint64_t append_size);
 
 #endif /* COW_MANAGER_H_ */

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -44,8 +44,8 @@ struct cow_section {
 struct cow_auto_expand_manager {
         struct mutex lock;
 
-        uint64_t step_size;
-        long steps;
+        uint64_t step_size_mib;
+        uint64_t reserved_space_mib;
 };
 
 struct cow_manager {
@@ -110,13 +110,15 @@ int __cow_write_mapping(struct cow_manager *cm, uint64_t pos, uint64_t val);
 
 int cow_get_file_extents(struct snap_device* dev, struct file* filp);
 
-int __cow_expand_datastore(struct cow_manager *cm, uint64_t append_size);
+int __cow_expand_datastore(struct cow_manager *cm, uint64_t append_size_bytes);
 
 struct cow_auto_expand_manager* cow_auto_expand_manager_init(void);
 
-int cow_auto_expand_manager_reconfigure(struct cow_auto_expand_manager* aem, uint64_t step_size, long steps);
+int cow_auto_expand_manager_reconfigure(struct cow_auto_expand_manager* aem, uint64_t step_size_mib, uint64_t reserved_space_mib);
 
-uint64_t cow_auto_expand_manager_test_and_dec(struct cow_auto_expand_manager* aem);
+uint64_t cow_auto_expand_manager_get_allowance(struct cow_auto_expand_manager* aem, uint64_t available_blocks, uint64_t block_size_bytes);
+
+uint64_t cow_auto_expand_manager_get_allowance_free_unknown(struct cow_auto_expand_manager* aem);
 
 void cow_auto_expand_manager_free(struct cow_auto_expand_manager* aem);
 

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -40,12 +40,20 @@ struct cow_section {
         uint64_t *mappings;
 };
 
+// for now, auto expand settings are not preserved during reloads
+struct cow_auto_expand_manager {
+        struct mutex lock;
+
+        uint64_t step_size;
+        long steps;
+};
+
 struct cow_manager {
         struct dattobd_mutable_file *dfilp; // the file the cow manager is writing to
         uint32_t flags; // flags representing current state of cow manager
         uint64_t curr_pos; // current write head position
         uint64_t data_offset; // starting offset of data
-        uint64_t file_size; // current size of the file, max size before an error is thrown
+        uint64_t file_size; // current size of the file, max size before an error is thrown or file is expanded
         uint64_t seqid; // sequence id, increments on each transition to
                         // snapshot mode
         uint64_t version; // version of cow file format
@@ -63,6 +71,8 @@ struct cow_manager {
         struct cow_section *sects; // pointer to the array of sections of
                                    // mappings
         struct snap_device* dev;  //pointer to snapshot device
+
+        struct cow_auto_expand_manager* auto_expand; // auto expand settings
 };
 
 /***************************COW MANAGER FUNCTIONS**************************/
@@ -101,5 +111,13 @@ int __cow_write_mapping(struct cow_manager *cm, uint64_t pos, uint64_t val);
 int cow_get_file_extents(struct snap_device* dev, struct file* filp);
 
 int __cow_expand_datastore(struct cow_manager *cm, uint64_t append_size);
+
+struct cow_auto_expand_manager* cow_auto_expand_manager_init(void);
+
+int cow_auto_expand_manager_reconfigure(struct cow_auto_expand_manager* aem, uint64_t step_size, long steps);
+
+uint64_t cow_auto_expand_manager_test_and_dec(struct cow_auto_expand_manager* aem);
+
+void cow_auto_expand_manager_free(struct cow_auto_expand_manager* aem);
 
 #endif /* COW_MANAGER_H_ */

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -15,7 +15,7 @@
 #include <linux/limits.h>
 #include <linux/types.h>
 
-#define DATTOBD_VERSION "0.11.8.1"
+#define DATTOBD_VERSION "0.11.9"
 #define DATTO_IOCTL_MAGIC 0x91
 
 struct setup_params {

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -46,6 +46,11 @@ struct reconfigure_params {
         unsigned int minor; // requested minor number of the device
 };
 
+struct expand_cow_file_params {
+        unsigned int minor; // minor to extend
+        unsigned long size; // size in bytes
+};
+
 #define COW_UUID_SIZE 16
 #define COW_BLOCK_LOG_SIZE 12
 #define COW_BLOCK_SIZE (1 << COW_BLOCK_LOG_SIZE)
@@ -105,5 +110,7 @@ struct dattobd_info {
 #define IOCTL_DATTOBD_INFO                                                     \
         _IOR(DATTO_IOCTL_MAGIC, 8, struct dattobd_info) // in: see above
 #define IOCTL_GET_FREE _IOR(DATTO_IOCTL_MAGIC, 9, int)
+#define IOCTL_EXPAND_COW_FILE                                                  \
+        _IOW(DATTO_IOCTL_MAGIC, 10, struct expand_cow_file_params) // in: see above
 
 #endif /* DATTOBD_H_ */

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -51,6 +51,13 @@ struct expand_cow_file_params {
         unsigned long size; // size in bytes
 };
 
+struct reconfigure_auto_expand_params {
+        uint64_t step_size; // step size (in bytes)
+        long steps; // allowed steps (or -1 for unlimited)
+
+        unsigned int minor; // minor to configure
+};
+
 #define COW_UUID_SIZE 16
 #define COW_BLOCK_LOG_SIZE 12
 #define COW_BLOCK_SIZE (1 << COW_BLOCK_LOG_SIZE)
@@ -112,5 +119,8 @@ struct dattobd_info {
 #define IOCTL_GET_FREE _IOR(DATTO_IOCTL_MAGIC, 9, int)
 #define IOCTL_EXPAND_COW_FILE                                                  \
         _IOW(DATTO_IOCTL_MAGIC, 10, struct expand_cow_file_params) // in: see above
+#define IOCTL_RECONFIGURE_AUTO_EXPAND                                          \
+        _IOW(DATTO_IOCTL_MAGIC, 11, struct reconfigure_auto_expand_params) 
+                                                              // in: see above
 
 #endif /* DATTOBD_H_ */

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -47,13 +47,14 @@ struct reconfigure_params {
 };
 
 struct expand_cow_file_params {
+        uint64_t size; // size in mib
+
         unsigned int minor; // minor to extend
-        unsigned long size; // size in bytes
 };
 
 struct reconfigure_auto_expand_params {
-        uint64_t step_size; // step size (in bytes)
-        long steps; // allowed steps (or -1 for unlimited)
+        uint64_t step_size; // step size in mib
+        uint64_t reserved_space; // reserved space in mib
 
         unsigned int minor; // minor to configure
 };

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -11,21 +11,27 @@
 #include "userspace_copy_helpers.h"
 #include "snap_device.h"
 
-#define file_write(filp, dev, buf, offset, len) file_io(filp, dev, 1, buf, offset, len)
-#define file_read(filp, dev, buf, offset, len) file_io(filp, dev, 0, buf, offset, len)
+#define file_read(filp, dev, buf, offset, len) file_io(filp, dev, 0, buf, offset, len, NULL)
+
+#define file_write5(filp, dev, buf, offset, len) file_io(filp, dev, 1, buf, offset, len, NULL)
+#define file_write6(filp, dev, buf, offset, len, done) file_io(filp, dev, 1, buf, offset, len, done)
+
+#define _get_macro(_1,_2,_3,_4,_5,_6,NAME,...) NAME
+#define file_write(...) _get_macro(__VA_ARGS__, file_write6, file_write5)(__VA_ARGS__)
 
 #define file_unlink(filp) __file_unlink(filp, 0, 0)
 #define file_unlink_and_close(filp) __file_unlink(filp, 1, 0)
 #define file_unlink_and_close_force(filp) __file_unlink(filp, 1, 1)
 
-#define file_lock(filp) file_switch_lock(filp, true, false)
-#define file_unlock(filp) file_switch_lock(filp, false, false)
-#define file_unlock_mark_dirty(filp) file_switch_lock(filp, false, true)
+// #define file_lock(filp) file_switch_lock(filp, true, false)
+// #define file_unlock(filp) file_switch_lock(filp, false, false)
+// #define file_unlock_mark_dirty(filp) file_switch_lock(filp, false, true)
 
+// replaced with dattobd_mutable_file lock/unlock mechanism
 // INODE Attribute Locking is based on the S_IMMUTABLE flag
-#define inode_attr_is_locked(inode) ( (inode->i_flags) & S_IMMUTABLE )
-#define inode_attr_lock(inode) do{ inode->i_flags |= S_IMMUTABLE; } while(0)
-#define inode_attr_unlock(inode) do{ inode->i_flags &= ~S_IMMUTABLE; } while(0)
+// #define inode_attr_is_locked(inode) ( (inode->i_flags) & S_IMMUTABLE )
+// #define inode_attr_lock(inode) do{ inode->i_flags |= S_IMMUTABLE; } while(0)
+// #define inode_attr_unlock(inode) do{ inode->i_flags &= ~S_IMMUTABLE; } while(0)
 
 #ifndef HAVE_STRUCT_PATH
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20)
@@ -56,6 +62,23 @@ struct file;
 struct dentry;
 struct vfsmount;
 
+struct dattobd_mutable_file {
+        struct file *filp;
+        struct dentry *dentry;
+        struct inode *inode;
+        struct vfsmount *mnt;
+        
+        atomic_t writers;
+};
+
+struct dattobd_mutable_file* dattobd_mutable_file_wrap(struct file*);
+
+void dattobd_mutable_file_unlock(struct dattobd_mutable_file*);
+
+void dattobd_mutable_file_lock(struct dattobd_mutable_file*);
+
+void dattobd_mutable_file_unwrap(struct dattobd_mutable_file*);
+
 #ifndef HAVE_STRUCT_PATH
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20)
 struct path {
@@ -68,12 +91,20 @@ struct path {
 typedef mode_t fmode_t;
 #endif
 
-int file_io(struct file *filp, struct snap_device* dev, int is_write, void *buf, sector_t offset,
-            unsigned long len);
-
-void file_close(struct file *f);
-
 int file_open(const char *filename, int flags, struct file **filp);
+
+int file_io(struct dattobd_mutable_file *dfilp, struct snap_device* dev, int is_write, void *buf, sector_t offset,
+            unsigned long len, unsigned long *done);
+
+int file_truncate(struct dattobd_mutable_file *dfilp, loff_t len);
+
+int file_allocate(struct dattobd_mutable_file *dfilp, struct snap_device* dev, uint64_t offset, uint64_t length, uint64_t *done);
+
+int __file_unlink(struct dattobd_mutable_file* dfilp, int close, int force);
+
+void file_close(struct dattobd_mutable_file *filp);
+
+void __file_close_raw(struct file *dfilp);
 
 #if !defined(HAVE___DENTRY_PATH) && !defined(HAVE_DENTRY_PATH_RAW)
 int dentry_get_relative_pathname(struct dentry *dentry, char **buf,
@@ -83,7 +114,7 @@ int dentry_get_relative_pathname(struct dentry *dentry, char **buf,
                                  int *len_res);
 #endif
 
-int file_get_absolute_pathname(const struct file *filp, char **buf,
+int file_get_absolute_pathname(const struct dattobd_mutable_file *dfilp, char **buf,
                                int *len_res);
 
 int pathname_to_absolute(const char *pathname, char **buf, int *len_res);
@@ -93,12 +124,6 @@ int pathname_concat(const char *pathname1, const char *pathname2,
 
 int user_mount_pathname_concat(const char __user *user_mount_path,
                                const char *rel_path, char **path_out);
-
-int file_truncate(struct file *filp, loff_t len);
-
-int file_allocate(struct file *filp, struct snap_device* dev, uint64_t offset, uint64_t length);
-
-int __file_unlink(struct file *filp, int close, int force);
 
 #ifndef HAVE_NOOP_LLSEEK
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,35)
@@ -127,8 +152,6 @@ void dattobd_vm_area_free(struct vm_area_struct *vma);
 void dattobd_mm_lock(struct mm_struct* mm);
 
 void dattobd_mm_unlock(struct mm_struct* mm);
-
-void file_switch_lock(struct file* filp, bool lock, bool mark_dirty);
 
 int file_write_block(struct snap_device* dev, const void* block, size_t offset, size_t len);
 

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -22,6 +22,11 @@
 #define file_unlock(filp) file_switch_lock(filp, false, false)
 #define file_unlock_mark_dirty(filp) file_switch_lock(filp, false, true)
 
+// INODE Attribute Locking is based on the S_IMMUTABLE flag
+#define inode_attr_is_locked(inode) ( (inode->i_flags) & S_IMMUTABLE )
+#define inode_attr_lock(inode) do{ inode->i_flags |= S_IMMUTABLE; } while(0)
+#define inode_attr_unlock(inode) do{ inode->i_flags &= ~S_IMMUTABLE; } while(0)
+
 #ifndef HAVE_STRUCT_PATH
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,20)
 #define dattobd_get_dentry(f) (f)->f_dentry

--- a/src/includes.h
+++ b/src/includes.h
@@ -25,5 +25,6 @@
 #include <linux/vmalloc.h>
 #include <linux/fiemap.h>
 #include <linux/types.h>
+#include <linux/statfs.h>
 
 #endif

--- a/src/proc_seq_file.c
+++ b/src/proc_seq_file.c
@@ -207,6 +207,15 @@ static int dattobd_proc_show(struct seq_file *m, void *v)
                                                 "%llu,\n",
                                                 dev->sd_cow->nr_changed_blocks);
                                 }
+
+                                if(dev->sd_cow->auto_expand){
+                                        seq_printf(m, "\t\t\t\"auto_expand\": {\n");
+                                        seq_printf(m, "\t\t\t\t\"step_size\": %llu,\n",
+                                                   (unsigned long long)dev->sd_cow->auto_expand->step_size);
+                                        seq_printf(m, "\t\t\t\t\"steps\": %ld\n",
+                                                   dev->sd_cow->auto_expand->steps);
+                                        seq_printf(m, "\t\t\t},\n");
+                                }
                         }
                 }
 

--- a/src/proc_seq_file.c
+++ b/src/proc_seq_file.c
@@ -210,10 +210,10 @@ static int dattobd_proc_show(struct seq_file *m, void *v)
 
                                 if(dev->sd_cow->auto_expand){
                                         seq_printf(m, "\t\t\t\"auto_expand\": {\n");
-                                        seq_printf(m, "\t\t\t\t\"step_size\": %llu,\n",
-                                                   (unsigned long long)dev->sd_cow->auto_expand->step_size);
-                                        seq_printf(m, "\t\t\t\t\"steps\": %ld\n",
-                                                   dev->sd_cow->auto_expand->steps);
+                                        seq_printf(m, "\t\t\t\t\"step_size_mib\": %llu,\n",
+                                                   (unsigned long long)dev->sd_cow->auto_expand->step_size_mib);
+                                        seq_printf(m, "\t\t\t\t\"reserved_space_mib\": %llu\n",
+                                                   dev->sd_cow->auto_expand->reserved_space_mib);
                                         seq_printf(m, "\t\t\t},\n");
                                 }
                         }

--- a/src/proc_seq_file.c
+++ b/src/proc_seq_file.c
@@ -183,6 +183,9 @@ static int dattobd_proc_show(struct seq_file *m, void *v)
 
                         if (dev->sd_cow) {
                                 int i;
+                                seq_printf(m, "\t\t\t\"cow_size_current\": %llu,\n",
+                                   (unsigned long long)dev->sd_cow->file_size);
+
                                 seq_printf(
                                         m, "\t\t\t\"seq_id\": %llu,\n",
                                         (unsigned long long)dev->sd_cow->seqid);

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -406,26 +406,26 @@ static int bdev_is_already_traced(const struct block_device *bdev)
 }
 
 /**
- * file_is_on_bdev() - Checks to see if the &struct file object is contained
+ * file_is_on_bdev() - Checks to see if the &struct dattobd mutable file object is contained
  * within the &struct block_device device.
  *
- * @file: the file to check
- * @bdev: the &struct block_device that might hold the @file.
+ * @dfilp: A dattobd mutable file object.
+ * @bdev: the &struct block_device that might hold the @dfilp.
  *
  * Return:
- * * 0 - the @file is not on the @bdev.
- * * !0 - the @file is on the @bdev.
+ * * 0 - the @dfilp is not on the @bdev.
+ * * !0 - the @dfilp is on the @bdev.
  */
-static int file_is_on_bdev(const struct file *file, struct block_device *bdev)
+static int file_is_on_bdev(const struct dattobd_mutable_file *dfilp, struct block_device *bdev)
 {
         struct super_block *sb = dattobd_get_super(bdev);
-        struct super_block *sb_file = (dattobd_get_mnt(file))->mnt_sb;
+        struct super_block *sb_file = dfilp->mnt->mnt_sb;
         int ret = 0;
 
         if (sb) {
                 LOG_DEBUG("file_is_on_bdev() if(sb)");
                 LOG_DEBUG("sb name:%s, file->sb name:%s", sb->s_root->d_name.name, sb_file->s_root->d_name.name);
-                ret = ((dattobd_get_mnt(file))->mnt_sb == sb);
+                ret = (dfilp->mnt->mnt_sb == sb);
                 dattobd_drop_super(sb);
         }
         return ret;
@@ -661,13 +661,13 @@ static int __tracer_setup_cow(struct snap_device *dev,
                         if (ret)
                                 goto error;
 
-                        dev->sd_falloc_size = dev->sd_cow->file_max;
+                        dev->sd_falloc_size = dev->sd_cow->file_size;
                         do_div(dev->sd_falloc_size, (1024 * 1024));
                 }
         }
 
         // verify that file is on block device
-        if (!file_is_on_bdev(dev->sd_cow->filp, bdev)) {
+        if (!file_is_on_bdev(dev->sd_cow->dfilp, bdev)) {
                 ret = -EINVAL;
 #ifdef HAVE_BDEVNAME
                 LOG_ERROR(ret, "'%s' is not on '%s'", cow_path, bdev_name);
@@ -679,7 +679,7 @@ static int __tracer_setup_cow(struct snap_device *dev,
 
         // find the cow file's inode number
         LOG_DEBUG("finding cow file inode");
-        dev->sd_cow_inode = dattobd_get_dentry(dev->sd_cow->filp)->d_inode;
+        dev->sd_cow_inode = dev->sd_cow->dfilp->inode;
 
         return 0;
 
@@ -885,20 +885,20 @@ static void __tracer_destroy_cow_path(struct snap_device *dev)
  * __tracer_setup_cow_path() - Sets up the COW file path given a &struct file.
  *
  * @dev: The &struct snap_device object pointer.
- * @cow_file: The &struct file object pointer.
+ * @cow_dfile: A &struct dattobd_mutable_file object pointer.
  *
  * Return:
  * * 0 - success
  * * !0 - errno indicating the error
  */
 static int __tracer_setup_cow_path(struct snap_device *dev,
-                                   const struct file *cow_file)
+                                   const struct dattobd_mutable_file *cow_dfile)
 {
         int ret;
 
         // get the pathname of the cow file (relative to the mountpoint)
         LOG_DEBUG("getting relative pathname of cow file");
-        ret = dentry_get_relative_pathname(dattobd_get_dentry(cow_file),
+        ret = dentry_get_relative_pathname(cow_dfile->dentry,
                                            &dev->sd_cow_path, NULL);
         if (ret)
                 goto error;
@@ -1884,7 +1884,7 @@ int tracer_setup_active_snap(struct snap_device *dev, unsigned int minor,
                 goto error;
 
         // setup the cow path
-        ret = __tracer_setup_cow_path(dev, dev->sd_cow->filp);
+        ret = __tracer_setup_cow_path(dev, dev->sd_cow->dfilp);
         if (ret)
                 goto error;
 
@@ -2002,7 +2002,7 @@ int tracer_active_snap_to_inc(struct snap_device *old_dev)
         ret = cow_truncate_to_index(dev->sd_cow);
         if (ret) {
                 // not a critical error, we can just print a warning
-                file_get_absolute_pathname(dev->sd_cow->filp, &abs_path,
+                file_get_absolute_pathname(dev->sd_cow->dfilp, &abs_path,
                                            &abs_path_len);
                 if (!abs_path) {
                         LOG_WARN("warning: cow file truncation failed, "
@@ -2075,7 +2075,7 @@ int tracer_active_inc_to_snap(struct snap_device *old_dev, const char *cow_path,
                 goto error;
 
         // setup the cow path
-        ret = __tracer_setup_cow_path(dev, dev->sd_cow->filp);
+        ret = __tracer_setup_cow_path(dev, dev->sd_cow->dfilp);
         if (ret)
                 goto error;
 
@@ -2153,7 +2153,7 @@ void tracer_dattobd_info(const struct snap_device *dev,
         strlcpy(info->bdev, dev->sd_bdev_path, PATH_MAX);
 
         if (!test_bit(UNVERIFIED, &dev->sd_state)) {
-                info->falloc_size = dev->sd_cow->file_max;
+                info->falloc_size = dev->sd_cow->file_size;
                 info->seqid = dev->sd_cow->seqid;
                 memcpy(info->uuid, dev->sd_cow->uuid, COW_UUID_SIZE);
                 info->version = dev->sd_cow->version;
@@ -2247,7 +2247,7 @@ void __tracer_unverified_snap_to_active(struct snap_device *dev,
                 goto error;
 
         // setup the cow path
-        ret = __tracer_setup_cow_path(dev, dev->sd_cow->filp);
+        ret = __tracer_setup_cow_path(dev, dev->sd_cow->dfilp);
         if (ret)
                 goto error;
 
@@ -2343,7 +2343,7 @@ void __tracer_unverified_inc_to_active(struct snap_device *dev,
                 goto error;
 
         // setup the cow path
-        ret = __tracer_setup_cow_path(dev, dev->sd_cow->filp);
+        ret = __tracer_setup_cow_path(dev, dev->sd_cow->dfilp);
         if (ret)
                 goto error;
 
@@ -2440,4 +2440,24 @@ error:
         if (cow_path)
                 kfree(cow_path);
         tracer_set_fail_state(dev, ret);
+}
+
+int tracer_expand_cow_file(struct snap_device *dev, uint64_t size){
+        int ret;
+        LOG_DEBUG("ENTER tracer_expand_cow_file");
+        if(tracer_read_fail_state(dev)){
+                LOG_ERROR(-EBUSY, "cannot expand cow file for device in error state");
+                return -EBUSY;
+        }
+
+        ret = __cow_expand_datastore(dev->sd_cow, size);
+
+        if(ret){
+                LOG_ERROR(ret, "error expanding cow file");
+                tracer_set_fail_state(dev, ret);
+                // __tracer_destroy_cow_thread(dev); -- we can't ask for thread destroy, as this function may be called from cow thread
+                // cow_thread must fail in a few moments
+        }
+
+        return ret;
 }

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1973,6 +1973,10 @@ int tracer_active_snap_to_inc(struct snap_device *old_dev)
         // thread to prevent concurrent access.
         __tracer_destroy_cow_thread(old_dev);
 
+        // disable auto-expand
+        cow_auto_expand_manager_free(old_dev->sd_cow->auto_expand);
+        old_dev->sd_cow->auto_expand = NULL;
+
         // sanity check to ensure no errors have occurred while cleaning up the
         // old cow thread
         ret = tracer_read_fail_state(old_dev);

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -2446,15 +2446,15 @@ error:
         tracer_set_fail_state(dev, ret);
 }
 
-int tracer_expand_cow_file(struct snap_device *dev, uint64_t size){
+int tracer_expand_cow_file_no_check(struct snap_device *dev, uint64_t by_size_bytes){
         int ret;
-        LOG_DEBUG("ENTER tracer_expand_cow_file");
+        LOG_DEBUG("ENTER tracer_expand_cow_file_no_check");
         if(tracer_read_fail_state(dev)){
                 LOG_ERROR(-EBUSY, "cannot expand cow file for device in error state");
                 return -EBUSY;
         }
 
-        ret = __cow_expand_datastore(dev->sd_cow, size);
+        ret = __cow_expand_datastore(dev->sd_cow, by_size_bytes);
 
         if(ret){
                 LOG_ERROR(ret, "error expanding cow file");

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -52,7 +52,7 @@ void tracer_reconfigure(struct snap_device *dev, unsigned long cache_size);
 void tracer_dattobd_info(const struct snap_device *dev,
                          struct dattobd_info *info);
 
-int tracer_expand_cow_file(struct snap_device *dev, uint64_t size);
+int tracer_expand_cow_file_no_check(struct snap_device *dev, uint64_t size);
 
 /************************AUTOMATIC TRANSITION FUNCTIONS************************/
 

--- a/src/tracer.h
+++ b/src/tracer.h
@@ -52,6 +52,8 @@ void tracer_reconfigure(struct snap_device *dev, unsigned long cache_size);
 void tracer_dattobd_info(const struct snap_device *dev,
                          struct dattobd_info *info);
 
+int tracer_expand_cow_file(struct snap_device *dev, uint64_t size);
+
 /************************AUTOMATIC TRANSITION FUNCTIONS************************/
 
 void __tracer_active_to_dormant(struct snap_device *dev);


### PR DESCRIPTION
Changes:
- **[FIX]** DattoBD failed to truncate file after transition from snapshot to incremental and failed to unlink file on reboot on Debian-based systems.
- **[FIX]** DattoBD used slower way to reserve file space, which led to dramatic decrease of performance on some systems.
- **[FEATURE]** Added an ability to expand COW-file in during active snapshot mode in manual way (using `ioctl`).
- **[FEATURE]** Added an ability to enable COW-file auto-expand, when it runs out of space.