### PR TITLE
DattoBD 0.11.10 Release

### DIFF
--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -432,6 +432,9 @@ if [ "$1" -ge "1" ]; then
     if [ -f /usr/lib/dkms/common.postinst ]; then
         /usr/lib/dkms/common.postinst %{name} %{version}
         exit $?
+    else
+        dkms add -m %{name} -v %{version} && dkms autoinstall
+        exit $?
     fi
 fi
 

--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -320,6 +320,13 @@ sed -e "s:@prefix@:%{_prefix}:g" \
 # Generate symbols for library package (Debian/Ubuntu only)
 %if "%{_vendor}" == "debbuild"
 mkdir -p %{buildroot}/%{libname}/DEBIAN
+
+# Ubuntu 24.04 LTS have broken dpkg-gensymbols usage without debian/control file. So, let us emulate it.
+%if 0%{?ubuntu} && 0%{?ubuntu} >= 2404
+mkdir debian
+touch debian/control
+%endif
+
 dpkg-gensymbols -P%{buildroot} -p%{libname} -v%{version}-%{release} -e%{buildroot}%{_libdir}/%{libprefix}.so.%{?!libsover:0}%{?libsover} -e%{buildroot}%{_libdir}/%{libprefix}.so.%{?!libsover:0}%{?libsover}.* -O%{buildroot}/%{libname}/DEBIAN/symbols
 %endif
 

--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -433,7 +433,8 @@ if [ "$1" -ge "1" ]; then
         /usr/lib/dkms/common.postinst %{name} %{version}
         exit $?
     else
-        dkms add -m %{name} -v %{version} && dkms autoinstall
+        dkms add -m %{name} -v %{version} %{?rpm_dkms_opt:--rpm_safe_upgrade}
+        dkms install -m %{name} -v %{version} --force
         exit $?
     fi
 fi

--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -117,7 +117,7 @@
 
 
 Name:            dattobd
-Version:         0.11.9
+Version:         0.11.10
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Datto, Inc.

--- a/src/blkdev.h
+++ b/src/blkdev.h
@@ -7,6 +7,7 @@
 #ifndef BLKDEV_H_
 #define BLKDEV_H_
 
+#include "config.h"
 #include "includes.h"
 
 struct block_device;
@@ -15,6 +16,21 @@ struct block_device;
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
 #define bdev_whole(bdev) ((bdev)->bd_contains)
 #endif
+
+struct bdev_wrapper{
+    struct block_device* bdev;
+
+    union {
+#ifdef HAVE_BDEV_HANDLE
+        struct bdev_handle* handle;
+#endif
+// Kernel 6.9+ manages block_device with struct file and file_bdev has to be used to find block_device from file.
+// For us, file_bdev function is marker to check if we have to use 
+#ifdef USE_BDEV_AS_FILE
+        struct file* file;
+#endif
+    } _internal;
+};
 
 #ifndef HAVE_HD_STRUCT
 //#if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
@@ -27,14 +43,14 @@ struct block_device;
 #endif
 
 
-struct block_device *dattodb_blkdev_by_path(const char *path, fmode_t mode,
+struct bdev_wrapper *dattobd_blkdev_by_path(const char *path, fmode_t mode,
                                         void *holder);
 
 struct super_block *dattobd_get_super(struct block_device * bd);
 
 void dattobd_drop_super(struct super_block *sb);
 
-void dattobd_blkdev_put(struct block_device *bd);
+void dattobd_blkdev_put(struct bdev_wrapper *bd);
 
 int dattobd_get_start_sect_by_gendisk_for_bio(struct gendisk* gd, u8 partno, sector_t* result);
 

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,5 @@
+#if defined HAVE_BDEV_FILE_OPEN_BY_PATH && defined HAVE_FILE_BDEV
+
+#define USE_BDEV_AS_FILE
+
+#endif

--- a/src/configure-tests/feature-tests/bdev_file_open_by_path.c
+++ b/src/configure-tests/feature-tests/bdev_file_open_by_path.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct file *file __attribute__ ((unused)) = NULL;
+    const char *path = "";
+    fmode_t mode = 0;
+    void *holder = NULL;
+    struct blk_holder_ops h;
+
+    file = bdev_file_open_by_path(path, mode, holder, &h);
+}

--- a/src/configure-tests/feature-tests/bdev_freeze.c
+++ b/src/configure-tests/feature-tests/bdev_freeze.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device bh;
+
+    bdev_freeze(&bh);
+}

--- a/src/configure-tests/feature-tests/bdev_handle.c
+++ b/src/configure-tests/feature-tests/bdev_handle.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct bdev_handle bh;
+    
+    struct block_device bd;
+    int holder;
+
+    bh.bdev = &bd;
+    bh.holder = (void*)&holder;
+}

--- a/src/configure-tests/feature-tests/bdev_open_by_path.c
+++ b/src/configure-tests/feature-tests/bdev_open_by_path.c
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct bdev_handle* bh;
+    
+    const char *path;
+    blk_mode_t mode;
+    int holder;
+    const struct blk_holder_ops bho;
+
+    bh = bdev_open_by_path(path, mode, (void*)&holder, &bho);
+}

--- a/src/configure-tests/feature-tests/bdev_release.c
+++ b/src/configure-tests/feature-tests/bdev_release.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct bdev_handle bh;
+
+    bdev_release(&bh);
+}

--- a/src/configure-tests/feature-tests/bdev_thaw.c
+++ b/src/configure-tests/feature-tests/bdev_thaw.c
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device bh;
+
+    bdev_thaw(&bh);
+}

--- a/src/configure-tests/feature-tests/file_bdev.c
+++ b/src/configure-tests/feature-tests/file_bdev.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct block_device* __attribute__ ((unused)) bd;
+    struct file* file = NULL;
+	
+    bd = file_bdev(file);
+}

--- a/src/configure-tests/feature-tests/vm_area_struct_vm_lock.c
+++ b/src/configure-tests/feature-tests/vm_area_struct_vm_lock.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+	struct vm_area_struct *vma;
+    struct vma_lock vma_lock;
+    
+    vma->vm_lock = &vma_lock;
+}

--- a/src/configure-tests/symbol-tests
+++ b/src/configure-tests/symbol-tests
@@ -9,3 +9,4 @@ vm_area_free
 insert_vm_struct
 vm_area_cachep
 get_active_super
+vma_lock_cachep

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -957,7 +957,7 @@ retry:
                 if(cm->auto_expand){
                         kstatfs_ret = 0;
                         if(cm->dev && cm->dev->sd_base_dev){
-                                kstatfs_ret = dattobd_get_kstatfs(cm->dev->sd_base_dev, &kstatfs);
+                                kstatfs_ret = dattobd_get_kstatfs(cm->dev->sd_base_dev->bdev, &kstatfs);
                         }
 
                         if(!kstatfs_ret){
@@ -1138,7 +1138,6 @@ int cow_get_file_extents(struct snap_device* dev, struct file* filp)
 
         ret = insert_vm_struct(task->mm, vma);
         if (ret < 0) {
-		ret = -EINVAL;
 		LOG_ERROR(ret, "insert_vm_struct() failed");
 		dattobd_vm_area_free(vma);
 		dattobd_mm_unlock(task->mm);
@@ -1147,7 +1146,6 @@ int cow_get_file_extents(struct snap_device* dev, struct file* filp)
 
         pg = alloc_pages(GFP_USER, get_order(cow_ext_buf_size));
 	if (!pg) {
-		ret = -ENOMEM;
 		LOG_ERROR(ret, "alloc_page() failed");
 		dattobd_vm_area_free(vma);
 		dattobd_mm_unlock(task->mm);

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -15,7 +15,7 @@
 #include <linux/limits.h>
 #include <linux/types.h>
 
-#define DATTOBD_VERSION "0.11.9"
+#define DATTOBD_VERSION "0.11.10"
 #define DATTO_IOCTL_MAGIC 0x91
 
 struct setup_params {

--- a/src/includes.h
+++ b/src/includes.h
@@ -25,6 +25,7 @@
 #include <linux/vmalloc.h>
 #include <linux/fiemap.h>
 #include <linux/types.h>
+#include <linux/rwsem.h>
 #include <linux/statfs.h>
 
 #endif

--- a/src/ioctl_handlers.c
+++ b/src/ioctl_handlers.c
@@ -97,24 +97,24 @@ static int __verify_minor(unsigned int minor, int mode)
 int __verify_bdev_writable(const char *bdev_path, int *out)
 {
         int writable = 0;
-        struct block_device *bdev;
+        struct bdev_wrapper *bdev_w;
         struct super_block *sb;
 
         // open the base block device
-        bdev = dattodb_blkdev_by_path(bdev_path, FMODE_READ, NULL);
+        bdev_w = dattobd_blkdev_by_path(bdev_path, FMODE_READ, NULL);
 
-        if (IS_ERR(bdev)) {
+        if (IS_ERR(bdev_w)) {
                 *out = 0;
-                return PTR_ERR(bdev);
+                return PTR_ERR(bdev_w);
         }
 
-        sb = dattobd_get_super(bdev);
+        sb = dattobd_get_super(bdev_w->bdev);
         if (sb) {
                 writable = !(sb->s_flags & MS_RDONLY);
                 dattobd_drop_super(sb);
         }
 
-        dattobd_blkdev_put(bdev);
+        dattobd_blkdev_put(bdev_w);
         *out = writable;
         return 0;
 }

--- a/src/snap_device.h
+++ b/src/snap_device.h
@@ -13,6 +13,7 @@
 #include "includes.h"
 #include "submit_bio.h"
 #include "sset_queue.h"
+#include "blkdev.h"
 
 // macros for defining the state of a tracing struct (bit offsets)
 #define SNAPSHOT 0
@@ -55,7 +56,7 @@ struct snap_device {
         sector_t sd_size; // size of device in sectors
         struct request_queue *sd_queue; // snap device request queue
         struct gendisk *sd_gd; // snap device gendisk
-        struct block_device *sd_base_dev; // device being snapshot
+        struct bdev_wrapper *sd_base_dev; // device being snapshot
         char *sd_bdev_path; // base device file path
         struct cow_manager *sd_cow; // cow manager
         char *sd_cow_path; // cow file path

--- a/src/snap_handle.c
+++ b/src/snap_handle.c
@@ -125,7 +125,7 @@ int snap_handle_read_bio(const struct snap_device *dev, struct bio *bio)
         bio_orig_size = bio_size(bio);
         bio_orig_sect = bio_sector(bio);
 
-        dattobd_bio_set_dev(bio, dev->sd_base_dev);
+        dattobd_bio_set_dev(bio, dev->sd_base_dev->bdev);
         dattobd_set_bio_ops(bio, REQ_OP_READ, READ_SYNC);
 
         // detect fastpath for bios completely contained within either the cow

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -398,7 +398,7 @@ static int bdev_is_already_traced(const struct block_device *bdev)
         {
                 if (!dev || test_bit(UNVERIFIED, &dev->sd_state))
                         continue;
-                if (dev->sd_base_dev == bdev)
+                if (dev->sd_base_dev->bdev == bdev)
                         return 1;
         }
 
@@ -730,13 +730,13 @@ static int __tracer_setup_base_dev(struct snap_device *dev,
 
         // open the base block device
         LOG_DEBUG("ENTER __tracer_setup_base_dev");
-        dev->sd_base_dev = dattodb_blkdev_by_path(bdev_path, FMODE_READ, NULL);
+        dev->sd_base_dev = dattobd_blkdev_by_path(bdev_path, FMODE_READ, NULL);
         if (IS_ERR(dev->sd_base_dev)) {
                 ret = PTR_ERR(dev->sd_base_dev);
                 dev->sd_base_dev = NULL;
                 LOG_ERROR(ret, "error finding block device '%s'", bdev_path);
                 goto error;
-        } else if (!dev->sd_base_dev->bd_disk) {
+        } else if (!dev->sd_base_dev->bdev->bd_disk) {
                 ret = -EFAULT;
                 LOG_ERROR(ret, "error finding block device gendisk");
                 goto error;
@@ -744,7 +744,7 @@ static int __tracer_setup_base_dev(struct snap_device *dev,
 
         // check block device is not already being traced
         LOG_DEBUG("checking block device is not already being traced");
-        if (bdev_is_already_traced(dev->sd_base_dev)) {
+        if (bdev_is_already_traced(dev->sd_base_dev->bdev)) {
                 ret = -EINVAL;
                 LOG_ERROR(ret, "block device is already being traced");
                 goto error;
@@ -758,12 +758,12 @@ static int __tracer_setup_base_dev(struct snap_device *dev,
 
         // check if device represents a partition, calculate size and offset
         LOG_DEBUG("calculating block device size and offset");
-        if (bdev_whole(dev->sd_base_dev) != dev->sd_base_dev) {
-                dev->sd_sect_off = get_start_sect(dev->sd_base_dev);
-                dev->sd_size = dattobd_bdev_size(dev->sd_base_dev);
+        if (bdev_whole(dev->sd_base_dev->bdev) != dev->sd_base_dev->bdev) {
+                dev->sd_sect_off = get_start_sect(dev->sd_base_dev->bdev);
+                dev->sd_size = dattobd_bdev_size(dev->sd_base_dev->bdev);
         } else {
                 dev->sd_sect_off = 0;
-                dev->sd_size = get_capacity(dev->sd_base_dev->bd_disk);
+                dev->sd_size = get_capacity(dev->sd_base_dev->bdev->bd_disk);
         }
 
         LOG_DEBUG("bdev size = %llu, offset = %llu",
@@ -813,9 +813,9 @@ static int snap_merge_bvec(struct request_queue *q, struct bvec_merge_data *bvm,
                            struct bio_vec *bvec)
 {
         struct snap_device *dev = q->queuedata;
-        struct request_queue *base_queue = bdev_get_queue(dev->sd_base_dev);
+        struct request_queue *base_queue = bdev_get_queue(dev->sd_base_dev->bdev);
 
-        bvm->bi_bdev = dev->sd_base_dev;
+        bvm->bi_bdev = dev->sd_base_dev->bdev;
 
         return base_queue->merge_bvec_fn(base_queue, bvm, bvec);
 }
@@ -838,9 +838,9 @@ static int snap_merge_bvec(struct request_queue *q, struct bio *bio_bvm,
                            struct bio_vec *bvec)
 {
         struct snap_device *dev = q->queuedata;
-        struct request_queue *base_queue = bdev_get_queue(dev->sd_base_dev);
+        struct request_queue *base_queue = bdev_get_queue(dev->sd_base_dev->bdev);
 
-        bio_bvm->bi_bdev = dev->sd_base_dev;
+        bio_bvm->bi_bdev = dev->sd_base_dev->bdev;
 
         return base_queue->merge_bvec_fn(base_queue, bio_bvm, bvec);
 }
@@ -1294,6 +1294,8 @@ static int __tracer_transition_tracing(
 #endif
                         return (int)PTR_ERR(sb);
                 }
+#elif defined HAVE_BDEV_FREEZE
+                ret = bdev_freeze(bdev);
 #else
                 ret = freeze_bdev(bdev);
                 if (ret) {
@@ -1362,6 +1364,8 @@ static int __tracer_transition_tracing(
 #endif                
 #ifdef HAVE_THAW_BDEV_INT
                 ret = thaw_bdev(bdev, sb);
+#elif defined HAVE_BDEV_THAW
+                ret = bdev_thaw(bdev);
 #else
                 ret = thaw_bdev(bdev);
 #endif
@@ -1498,7 +1502,7 @@ static int dattobd_find_orig_mrf(struct block_device *bdev,
 
         tracer_for_each(dev, i){
                 if(!dev || test_bit(UNVERIFIED, &dev->sd_state)) continue;
-                if(q == bdev_get_queue(dev->sd_base_dev)){
+                if(q == bdev_get_queue(dev->sd_base_dev->bdev)){
                         *mrf = dev->sd_orig_request_fn;
                         return 0;
                 }
@@ -1535,7 +1539,7 @@ int find_orig_bdops(struct block_device *bdev, struct block_device_operations **
 
         tracer_for_each(dev, i){
 		if(!dev || test_bit(UNVERIFIED, &dev->sd_state)) continue;
-		if(orig_ops == dattobd_get_bd_ops(dev->sd_base_dev)){
+		if(orig_ops == dattobd_get_bd_ops(dev->sd_base_dev->bdev)){
 			*ops = dev->bd_ops;
 			*mrf = dev->sd_orig_request_fn;
                         *trops=tracing_ops_get(dev->sd_tracing_ops);
@@ -1565,10 +1569,10 @@ int tracer_alloc_ops(struct snap_device* dev){
                 LOG_ERROR(-ENOMEM, "error while alocating new block_device_operations");
                 return -ENOMEM;
         }
-        memcpy(trops->bd_ops, dattobd_get_bd_ops(dev->sd_base_dev),sizeof(struct block_device_operations));
+        memcpy(trops->bd_ops, dattobd_get_bd_ops(dev->sd_base_dev->bdev),sizeof(struct block_device_operations));
         trops->bd_ops->submit_bio = tracing_fn;
 #ifdef HAVE_BD_HAS_SUBMIT_BIO
-        trops->has_submit_bio=dev->sd_base_dev->bd_has_submit_bio;
+        trops->has_submit_bio=dev->sd_base_dev->bdev->bd_has_submit_bio;
 #endif
         atomic_set(&trops->refs, 1);
 	dev->sd_tracing_ops = trops;
@@ -1590,12 +1594,12 @@ static int __tracer_should_reset_mrf(const struct snap_device *dev)
 {
     int i;
     struct snap_device *cur_dev;
-    struct request_queue *q = bdev_get_queue(dev->sd_base_dev);
+    struct request_queue *q = bdev_get_queue(dev->sd_base_dev->bdev);
 
 #ifndef USE_BDOPS_SUBMIT_BIO
-    if (GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev) != tracing_fn) return 0;
+    if (GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev->bdev) != tracing_fn) return 0;
 #else
-        struct block_device_operations* ops=dattobd_get_bd_ops(dev->sd_base_dev);
+        struct block_device_operations* ops=dattobd_get_bd_ops(dev->sd_base_dev->bdev);
 #endif
     if (dev != snap_devices[dev->sd_minor]) return 0;
 
@@ -1605,9 +1609,9 @@ static int __tracer_should_reset_mrf(const struct snap_device *dev)
             if (!cur_dev || test_bit(UNVERIFIED, &cur_dev->sd_state) 
                 || cur_dev == dev) continue;
 #ifndef USE_BDOPS_SUBMIT_BIO
-            if (q == bdev_get_queue(cur_dev->sd_base_dev)) return 0;
+            if (q == bdev_get_queue(cur_dev->sd_base_dev->bdev)) return 0;
 #else
-                if(ops==dattobd_get_bd_ops(cur_dev->sd_base_dev)) return 0;
+                if(ops==dattobd_get_bd_ops(cur_dev->sd_base_dev->bdev)) return 0;
 #endif
         }
     }
@@ -1651,7 +1655,7 @@ static void __tracer_destroy_tracing(struct snap_device *dev)
 #ifndef USE_BDOPS_SUBMIT_BIO
                         __tracer_transition_tracing(
                             dev,
-                            dev->sd_base_dev,
+                            dev->sd_base_dev->bdev,
                             dev->sd_orig_request_fn,
                             &snap_devices[dev->sd_minor],
                             false
@@ -1659,7 +1663,7 @@ static void __tracer_destroy_tracing(struct snap_device *dev)
 #else
                         __tracer_transition_tracing(
                             dev,
-                            dev->sd_base_dev,
+                            dev->sd_base_dev->bdev,
                             dev->bd_ops,
                             &snap_devices[dev->sd_minor],
                             false
@@ -1670,7 +1674,7 @@ static void __tracer_destroy_tracing(struct snap_device *dev)
         {
                 __tracer_transition_tracing(
                         dev,
-                        dev->sd_base_dev,
+                        dev->sd_base_dev->bdev,
                         NULL,
                         &snap_devices[dev->sd_minor],
                         false
@@ -1733,18 +1737,18 @@ int __tracer_setup_tracing(struct snap_device *dev, unsigned int minor)
         LOG_DEBUG("getting the base block device's make_request_fn");
 
 #ifndef USE_BDOPS_SUBMIT_BIO
-        ret = dattobd_find_orig_mrf(dev->sd_base_dev, &dev->sd_orig_request_fn);
+        ret = dattobd_find_orig_mrf(dev->sd_base_dev->bdev, &dev->sd_orig_request_fn);
         if (ret)
                 goto error;
         ret = __tracer_transition_tracing(
                 dev,
-                dev->sd_base_dev,
+                dev->sd_base_dev->bdev,
                 tracing_fn,
                 &snap_devices[minor],
                 true);
 #else
         if(!dev->sd_tracing_ops){
-                ret=find_orig_bdops(dev->sd_base_dev, &dev->bd_ops,&dev->sd_orig_request_fn, &dev->sd_tracing_ops);
+                ret=find_orig_bdops(dev->sd_base_dev->bdev, &dev->bd_ops,&dev->sd_orig_request_fn, &dev->sd_tracing_ops);
                 if(ret) goto error;
 
                 if(!dev->sd_tracing_ops){
@@ -1759,7 +1763,7 @@ int __tracer_setup_tracing(struct snap_device *dev, unsigned int minor)
 
                 ret = __tracer_transition_tracing(
                         dev,
-                        dev->sd_base_dev,
+                        dev->sd_base_dev->bdev,
                         dev->sd_tracing_ops->bd_ops,
                         &snap_devices[minor],
                         true);
@@ -1882,7 +1886,7 @@ int tracer_setup_active_snap(struct snap_device *dev, unsigned int minor,
                 goto error;
 
         // setup the cow manager
-        ret = __tracer_setup_cow_new(dev, dev->sd_base_dev, cow_path,
+        ret = __tracer_setup_cow_new(dev, dev->sd_base_dev->bdev, cow_path,
                                      dev->sd_size, fallocated_space, cache_size,
                                      NULL, 1);
         if (ret)
@@ -1895,13 +1899,13 @@ int tracer_setup_active_snap(struct snap_device *dev, unsigned int minor,
 
 #ifndef USE_BDOPS_SUBMIT_BIO
         // retain an association between the original mrf and the block device
-        ret = mrf_get(dev->sd_base_dev->bd_disk, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev));
+        ret = mrf_get(dev->sd_base_dev->bdev->bd_disk, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev->bdev));
         if (ret)
                 goto error;
 #endif
 
         // setup the snapshot values
-        ret = __tracer_setup_snap(dev, minor, dev->sd_base_dev, dev->sd_size);
+        ret = __tracer_setup_snap(dev, minor, dev->sd_base_dev->bdev, dev->sd_size);
         if (ret)
                 goto error;
 
@@ -2076,7 +2080,7 @@ int tracer_active_inc_to_snap(struct snap_device *old_dev, const char *cow_path,
         __tracer_copy_base_dev(old_dev, dev);
 
         // setup the cow manager
-        ret = __tracer_setup_cow_new(dev, dev->sd_base_dev, cow_path,
+        ret = __tracer_setup_cow_new(dev, dev->sd_base_dev->bdev, cow_path,
                                      dev->sd_size, fallocated_space,
                                      dev->sd_cache_size, old_dev->sd_cow->uuid,
                                      old_dev->sd_cow->seqid + 1);
@@ -2089,7 +2093,7 @@ int tracer_active_inc_to_snap(struct snap_device *old_dev, const char *cow_path,
                 goto error;
 
         // setup the snapshot values
-        ret = __tracer_setup_snap(dev, old_dev->sd_minor, dev->sd_base_dev,
+        ret = __tracer_setup_snap(dev, old_dev->sd_minor, dev->sd_base_dev->bdev,
                                   dev->sd_size);
         if (ret)
                 goto error;
@@ -2158,8 +2162,8 @@ void tracer_dattobd_info(const struct snap_device *dev,
         info->cache_size = (dev->sd_cache_size) ?
                                    dev->sd_cache_size :
                                    dattobd_cow_max_memory_default;
-        strlcpy(info->cow, dev->sd_cow_path, PATH_MAX);
-        strlcpy(info->bdev, dev->sd_bdev_path, PATH_MAX);
+        strscpy(info->cow, dev->sd_cow_path, PATH_MAX);
+        strscpy(info->bdev, dev->sd_bdev_path, PATH_MAX);
 
         if (!test_bit(UNVERIFIED, &dev->sd_state)) {
                 info->falloc_size = dev->sd_cow->file_size;
@@ -2250,7 +2254,7 @@ void __tracer_unverified_snap_to_active(struct snap_device *dev,
                 goto error;
 
         // setup the cow manager
-        ret = __tracer_setup_cow_reload_snap(dev, dev->sd_base_dev, cow_path,
+        ret = __tracer_setup_cow_reload_snap(dev, dev->sd_base_dev->bdev, cow_path,
                                              dev->sd_size, dev->sd_cache_size);
         if (ret)
                 goto error;
@@ -2262,13 +2266,13 @@ void __tracer_unverified_snap_to_active(struct snap_device *dev,
 
 #ifndef USE_BDOPS_SUBMIT_BIO
         // retain an association between the original mrf and the block device
-        ret = mrf_get(dev->sd_base_dev->bd_disk, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev));
+        ret = mrf_get(dev->sd_base_dev->bdev->bd_disk, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev->bdev));
         if (ret)
                 goto error;
 #endif
 
         // setup the snapshot values
-        ret = __tracer_setup_snap(dev, minor, dev->sd_base_dev, dev->sd_size);
+        ret = __tracer_setup_snap(dev, minor, dev->sd_base_dev->bdev, dev->sd_size);
         if (ret)
                 goto error;
 
@@ -2346,7 +2350,7 @@ void __tracer_unverified_inc_to_active(struct snap_device *dev,
                 goto error;
 
         // setup the cow manager
-        ret = __tracer_setup_cow_reload_inc(dev, dev->sd_base_dev, cow_path,
+        ret = __tracer_setup_cow_reload_inc(dev, dev->sd_base_dev->bdev, cow_path,
                                             dev->sd_size, dev->sd_cache_size);
         if (ret)
                 goto error;
@@ -2358,7 +2362,7 @@ void __tracer_unverified_inc_to_active(struct snap_device *dev,
 
 #ifndef USE_BDOPS_SUBMIT_BIO
         // retain an association between the original mrf and the block device
-        ret = mrf_get(dev->sd_base_dev->bd_disk, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev));
+        ret = mrf_get(dev->sd_base_dev->bdev->bd_disk, GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev->bdev));
         if (ret)
                 goto error;
 #endif
@@ -2420,7 +2424,7 @@ void __tracer_dormant_to_active(struct snap_device *dev,
                 goto error;
 
         // setup the cow manager
-        ret = __tracer_setup_cow_reopen(dev, dev->sd_base_dev, cow_path);
+        ret = __tracer_setup_cow_reopen(dev, dev->sd_base_dev->bdev, cow_path);
         if (ret)
                 goto error;
 

--- a/src/tracer_helper.h
+++ b/src/tracer_helper.h
@@ -11,6 +11,7 @@
 #include "hints.h"
 #include "includes.h"
 #include "module_control.h"
+#include "blkdev.h"
 
 // macro for iterating over snap_devices (requires a null check on dev)
 #define tracer_for_each(dev, i)                                                \
@@ -25,7 +26,7 @@
 
 // returns true if tracing struct's base device queue matches that of bio
 #define tracer_queue_matches_bio(dev, bio)                                     \
-        (bdev_get_queue((dev)->sd_base_dev) == dattobd_bio_get_queue(bio))
+        (bdev_get_queue((dev)->sd_base_dev->bdev) == dattobd_bio_get_queue(bio))
 
 // returns true if tracing struct's sector range matches the sector of the bio
 #define tracer_sector_matches_bio(dev, bio)                                    \


### PR DESCRIPTION
Changes:
- Resolved issue, when `DattoBD` might cause a kernel oops with **Incorrect GFP Flags** bug.
- Provided support for Ubuntu 24.04
- Provided support for RHELs 9.5 (with exception of XFS)
- Fixed issue when the latest DKMS was unable to install `DattoBD` on RHELs