### PR TITLE
DattoBD 0.12.1 Release

### DIFF
--- a/dist/dattobd-dkms-conf
+++ b/dist/dattobd-dkms-conf
@@ -13,5 +13,3 @@ DEST_MODULE_LOCATION[0]="/kernel/drivers/block/"
 
 NO_WEAK_MODULES="yes"
 AUTOINSTALL="yes"
-REMAKE_INITRD="no"
-

--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -641,6 +641,31 @@ rm %{_systemd_shutdown}/umount_rootfs.shutdown
 rm %{_systemd_services}/umount-rootfs.service
 
 %changelog
+* Wed May 14 2025 Andrii Fylypiuk <andrii.fylypiuk@datto.com> - 0.12.1
+- Fixed warnings related to DKMS
+- Fixed build errors on SLE 15 SP5 and SP6
+- Fixed error related to the use of the wrong slab allocation flags
+- Fixed endless loop in internal thread in case of block device failure
+- Fixed build errors on CentOS 7.3
+- Fixed build errors on Oracle UEK
+- Fixed kernel hang when freeze fails
+- Fixed errors with System.map files on Debian 11
+- Fixed build errors on CentOS Stream 9 and 10
+
+* Wed Feb 12 2025 Andrii Fylypiuk <andrii.fylypiuk@datto.com> - 0.12.0
+- Fixed NULL-dereference errors during mount
+- Fixed kernel panic related to Docker
+- Patch to handle correctly file unlinking, which caused problems for Debian 12
+
+* Thu Dec 19 2024 Andrii Fylypiuk <andrii.fylypiuk@datto.com> - 0.11.10
+- Kernel 6.X support
+
+* Thu Nov 28 2024 Andrii Fylypiuk <andrii.fylypiuk@datto.com> - 0.11.9
+- Fixed error when COW file fails to truncate/unlink
+- Fixed lack of real_fallocate
+- COW-file Manual Expansion
+- COW-file Auto-Expand
+
 * Tue Sep 24 2024 Andrii Fylypiuk <andrii.fylypiuk@datto.com> - 0.11.8.1
 - Fixed panic on mount of snapshot device on RHEL 8.10 and systems with the same kernel
 

--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -136,7 +136,7 @@
 
 
 Name:            dattobd
-Version:         0.12.0
+Version:         0.12.1
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Datto, Inc.

--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -7,14 +7,33 @@
 %global _kmod_src_root %{_usrsrc}/%{name}-%{version}
 
 # Location for systemd shutdown script
-# "%{_vendor}" == "redhat" covers rhel, centos and fedora 
+# "%%{_vendor}" == "redhat" covers rhel, centos and fedora 
 # Ubuntu18 doesn't have /usr/lib/systemd/, but Ubuntu20 has both locations with the same content
-%if "%{_vendor}" == "redhat"
+%if "%{_vendor}" == "redhat" || "%{_vendor}" == "suse"
 %global _systemd_services          /usr/lib/systemd/system
 %global _systemd_shutdown          /usr/lib/systemd/system-shutdown
 %else
 %global _systemd_services          /lib/systemd/system
 %global _systemd_shutdown          /lib/systemd/system-shutdown
+%endif
+
+%if "%{_vendor}" == "suse"
+%global _bashcompletionpath      %{_datadir}/bash-completion/completions
+%else
+%global _bashcompletionpath      %{_sysconfdir}/bash_completion.d
+%endif
+
+%if "%{_vendor}" == "suse"
+%global _modules_load_root %{_prefix}/lib/modules-load.d
+%else
+%global _modules_load_root %{_sysconfdir}/modules-load.d
+%endif
+
+%if "%{_vendor}" == "suse"
+%if 0%{?suse_version} > 0 && 0%{?suse_version} >= 1500
+# Since SLES 15 SP 2, dattobd.ko is considered as requirement, we have to disable this behavior
+%global __requires_exclude ^.*dattobd\.ko.*$
+%endif
 %endif
 
 # All sane distributions use dracut now, so here are dracut paths for it
@@ -180,7 +199,7 @@ The library for communicating with the %{name} kernel module.
 
 
 %package -n %{devname}
-Summary:         Files for developing applications to use %{name}.
+Summary:         Files for developing applications to use %{name}
 %if "%{_vendor}" == "debbuild"
 Group:           libdevel
 License:         LGPL-2.1+
@@ -333,8 +352,8 @@ dpkg-gensymbols -P%{buildroot} -p%{libname} -v%{version}-%{release} -e%{buildroo
 # Install utilities and man pages
 mkdir -p %{buildroot}%{_bindir}
 install -p -m 0755 app/dbdctl %{buildroot}%{_bindir}/dbdctl
-mkdir -p %{buildroot}%{_sysconfdir}/bash_completion.d
-install -p -m 0755 app/bash_completion.d/dbdctl %{buildroot}%{_sysconfdir}/bash_completion.d/
+mkdir -p %{buildroot}%{_bashcompletionpath}
+install -p -m 0644 app/bash_completion.d/dbdctl %{buildroot}%{_bashcompletionpath}/
 mkdir -p %{buildroot}%{_mandir}/man8
 install -p -m 0644 doc/dbdctl.8 %{buildroot}%{_mandir}/man8/dbdctl.8
 install -p -m 0755 utils/update-img %{buildroot}%{_bindir}/update-img
@@ -349,8 +368,8 @@ install -m 0644 dist/dattobd-dkms-conf %{buildroot}%{_kmod_src_root}/dkms.conf
 sed -i "s/@MODULE_VERSION@/%{version}/g" %{buildroot}%{_kmod_src_root}/dkms.conf
 
 # Install modern modprobe stuff
-mkdir -p %{buildroot}%{_sysconfdir}/modules-load.d
-install -m 0644 dist/dattobd-modprobe-conf %{buildroot}%{_sysconfdir}/modules-load.d/%{name}.conf
+mkdir -p %{buildroot}%{_modules_load_root}
+install -m 0644 dist/dattobd-modprobe-conf %{buildroot}%{_modules_load_root}/%{name}.conf
 
 # Legacy automatic module loader for RHEL 5/6
 %if 0%{?rhel} && 0%{?rhel} < 7
@@ -499,7 +518,7 @@ rm -rf %{buildroot}
 %endif
 %{_bindir}/dbdctl
 %{_bindir}/update-img
-%{_sysconfdir}/bash_completion.d/dbdctl
+%{_bashcompletionpath}/dbdctl
 %{_mandir}/man8/dbdctl.8*
 %{_mandir}/man8/update-img.8*
 # Initramfs scripts for all but RHEL 5
@@ -582,9 +601,9 @@ ln -fs %{_systemd_services}/umount-rootfs.service   %{_systemd_services}/reboot.
 %endif
 %if 0%{?rhel} == 5 && 0%{?rhel} == 6 && 0%{?suse_version} == 1110
 # RHEL/CentOS 5/6 and SLE 11 don't support this at all
-%exclude %{_sysconfdir}/modules-load.d/dattobd.conf
+%exclude %{_modules_load_root}/dattobd.conf
 %else
-%config %{_sysconfdir}/modules-load.d/dattobd.conf
+%config %{_modules_load_root}/dattobd.conf
 %endif
 %if 0%{?rhel} && 0%{?rhel} < 7
 %config %{_sysconfdir}/sysconfig/modules/dattobd.modules

--- a/src/configure-tests/feature-tests/Makefile
+++ b/src/configure-tests/feature-tests/Makefile
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
+OBJ := $(TEST).o
+SRC := $(TEST).c
+
 obj-m := $(OBJ)
 
 KERNELVERSION ?= $(shell uname -r)
@@ -8,6 +11,7 @@ PWD := $(shell pwd)
 EXTRA_CFLAGS := -g -Werror -I$(src)/../..
 BUILDDIR ?= $(PWD)/build/$(OBJ)
 BUILDDIR_MAKEFILE ?= $(PWD)/build/$(OBJ)/Makefile
+BUILDDIR_SOURCE ?= $(PWD)/build/$(OBJ)/$(SRC)
 
 default: $(BUILDDIR_MAKEFILE)
 	$(MAKE) -C $(KDIR) M=$(BUILDDIR) src=$(PWD) modules
@@ -17,6 +21,7 @@ $(BUILDDIR):
 
 $(BUILDDIR_MAKEFILE): $(BUILDDIR)
 	touch "$@"
+	ln -sf $(PWD)/$(SRC) $(BUILDDIR_SOURCE)
 
 clean: $(BUILDDIR)
 	$(MAKE) -C $(KDIR) M=$(BUILDDIR) src=$(PWD) clean

--- a/src/configure-tests/feature-tests/bdev_set_flag.c
+++ b/src/configure-tests/feature-tests/bdev_set_flag.c
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2025 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+    struct block_device *bdev = NULL;
+    unsigned flag;
+
+    bdev_set_flag(bdev, flag);
+}
+ 

--- a/src/configure-tests/feature-tests/blk_alloc_disk_2.c
+++ b/src/configure-tests/feature-tests/blk_alloc_disk_2.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2025 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+    struct queue_limits *ql = NULL;
+    struct gendisk* gd;
+
+    (void) gd;
+
+    gd = blk_alloc_disk(ql, NUMA_NO_NODE);
+}

--- a/src/configure-tests/feature-tests/queue_limits_stack_bdev.c
+++ b/src/configure-tests/feature-tests/queue_limits_stack_bdev.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2024 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+    struct queue_limits *ql = NULL;
+    struct block_device *bdev = NULL;
+    sector_t offset;
+    const char* pfx = "";
+
+    queue_limits_stack_bdev(ql, bdev, offset, pfx);
+}

--- a/src/configure-tests/feature-tests/strlcpy.c
+++ b/src/configure-tests/feature-tests/strlcpy.c
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2025 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+    char *dest;
+    const char *src;
+    size_t count;
+    size_t ret;
+    
+    (void)ret;
+
+    ret = strlcpy(dest, src, count);
+}

--- a/src/configure-tests/feature-tests/strscpy.c
+++ b/src/configure-tests/feature-tests/strscpy.c
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2025 Datto Inc.
+ */
+
+#include "includes.h"
+
+MODULE_LICENSE("GPL");
+
+static inline void dummy(void){
+    char *dest;
+    const char *src;
+    size_t count;
+    ssize_t ret;
+    
+    (void)ret;
+
+    ret = strscpy(dest, src, count);
+}

--- a/src/configure-tests/symbol-tests
+++ b/src/configure-tests/symbol-tests
@@ -10,3 +10,4 @@ insert_vm_struct
 vm_area_cachep
 get_active_super
 vma_lock_cachep
+__get_unmapped_area

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -92,10 +92,10 @@ static int __cow_alloc_section(struct cow_manager *cm, unsigned long sect_idx,
 {
         if (zero)
                 cm->sects[sect_idx].mappings = (void *)get_zeroed_pages(
-                        GFP_KERNEL, cm->log_sect_pages);
+                        GFP_NOIO, cm->log_sect_pages);
         else
                 cm->sects[sect_idx].mappings = (void *)__get_free_pages(
-                        GFP_KERNEL, cm->log_sect_pages);
+                        GFP_NOIO, cm->log_sect_pages);
 
         if (!cm->sects[sect_idx].mappings) {
                 LOG_ERROR(-ENOMEM, "failed to allocate mappings at index %lu",

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -9,6 +9,7 @@
 #include "logging.h"
 #include "tracer.h"
 #include "blkdev.h"
+#include "memory.h"
 
 #ifdef HAVE_UUID_H
 #include <linux/uuid.h>
@@ -1117,7 +1118,7 @@ int cow_get_file_extents(struct snap_device* dev, struct file* filp)
 	LOG_DEBUG("attempting page stealing from %s", get_task_comm(parent_process_name, task));
 
         dattobd_mm_lock(task->mm);
-        start_addr = get_unmapped_area(NULL, 0, cow_ext_buf_size, 0, VM_READ | VM_WRITE);
+        start_addr = dattobd_get_unmapped_area(NULL, 0, cow_ext_buf_size, 0, VM_READ | VM_WRITE);
 
         if (IS_ERR_VALUE(start_addr))
 		return start_addr; // returns -EPERM if failed

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -15,7 +15,7 @@
 #include <linux/limits.h>
 #include <linux/types.h>
 
-#define DATTOBD_VERSION "0.12.0"
+#define DATTOBD_VERSION "0.12.1"
 #define DATTO_IOCTL_MAGIC 0x91
 
 struct setup_params {

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -50,13 +50,15 @@ static ssize_t dattobd_kernel_read(struct dattobd_mutable_file *dfilp, struct sn
                                    loff_t *pos)
 {
         ssize_t ret;
+#ifndef HAVE_KERNEL_READ_PPOS
+        mm_segment_t old_fs;
+#endif
 
         if(dfilp){
                 // no need for making file mutable at read?
                 dattobd_mutable_file_unlock(dfilp);
 #ifndef HAVE_KERNEL_READ_PPOS
                 //#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
-                mm_segment_t old_fs;
                 old_fs = get_fs();
                 set_fs(get_ds());
                 ret = vfs_read(dfilp->filp, (char __user *)buf, count, pos);
@@ -92,12 +94,14 @@ static ssize_t dattobd_kernel_write(struct dattobd_mutable_file *dfilp, struct s
                                     size_t count, loff_t *pos)
 {
         ssize_t ret;
+#ifndef HAVE_KERNEL_READ_PPOS
+        mm_segment_t old_fs;
+#endif
 
         if(dfilp){
                 dattobd_mutable_file_unlock(dfilp);
 #ifndef HAVE_KERNEL_WRITE_PPOS
                 //#if LINUX_VERSION_CODE < KERNEL_VERSION(4,14,0)
-                mm_segment_t old_fs;
 
                 old_fs = get_fs();
                 set_fs(get_ds());
@@ -1017,8 +1021,10 @@ void dattobd_inode_unlock(struct inode *inode)
 static struct kmem_cache **vm_area_cache = (VM_AREA_CACHEP_ADDR != 0) ?
 	(struct kmem_cache **) (VM_AREA_CACHEP_ADDR + (long long)(((void *)kfree) - (void *)KFREE_ADDR)) : NULL;
 
+#ifdef HAVE_VM_AREA_STRUCT_VM_LOCK
 static struct kmem_cache **vma_lock_cache = (VMA_LOCK_CACHEP_ADDR != 0) ?
 	(struct kmem_cache **) (VMA_LOCK_CACHEP_ADDR + (long long)(((void *)kfree) - (void *)KFREE_ADDR)) : NULL;
+#endif
 
 struct vm_area_struct* dattobd_vm_area_allocate(struct mm_struct* mm)
 {

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -1134,7 +1134,7 @@ write_bio:
 #ifdef HAVE_BIO_ALLOC
 	new_bio = bio_alloc(GFP_NOIO, 1);
 #else
-	new_bio = bio_alloc(bdev, 1, 0, GFP_KERNEL);
+	new_bio = bio_alloc(bdev, 1, 0, GFP_NOIO);
 #endif
         if(!new_bio){
 		ret = -ENOMEM;
@@ -1241,7 +1241,7 @@ read_bio:
 #ifdef HAVE_BIO_ALLOC
 	new_bio = bio_alloc(GFP_NOIO, 1);
 #else
-	new_bio = bio_alloc(bdev, 1, 0, GFP_KERNEL);
+	new_bio = bio_alloc(bdev, 1, 0, GFP_NOIO);
 #endif
         if(!new_bio){
 		ret = -ENOMEM;

--- a/src/genconfig.sh
+++ b/src/genconfig.sh
@@ -22,21 +22,30 @@ if [ ! -z "$1" ]; then
 	KERNEL_VERSION="$1"
 fi
 
-SYSTEM_MAP_FILE="/lib/modules/${KERNEL_VERSION}/System.map"
+SYSTEM_MAP_FILE_VARIANTS=(
+	"/lib/modules/${KERNEL_VERSION}/System.map"
+	"/boot/System.map-${KERNEL_VERSION}"
+	"/usr/lib/debug/boot/System.map-${KERNEL_VERSION}"
+)
 
-if [ ! -f "$SYSTEM_MAP_FILE" ]; then
-	# Use fallback location
-	SYSTEM_MAP_FILE="/boot/System.map-${KERNEL_VERSION}"
-	if [ -f "$SYSTEM_MAP_FILE" ]; then
-		if ! grep -q "__per_cpu_start" "$SYSTEM_MAP_FILE"; then
-			SYSTEM_MAP_FILE="/usr/lib/debug/boot/System.map-${KERNEL_VERSION}"
-		fi
+for FILE_VARIANT in ${SYSTEM_MAP_FILE_VARIANTS[@]}; do
+	if [ -f "$FILE_VARIANT" ] && grep -q '__per_cpu_start' "$FILE_VARIANT"; then
+		SYSTEM_MAP_FILE="$FILE_VARIANT"
+		break
+	fi
+done
+
+if [ -z "$SYSTEM_MAP_FILE" ]; then
+	if [ "$(uname -r)" == "${KERNEL_VERSION}" ]; then
+		echo "System.map file not found for current kernel version; using /proc/kallsyms"
+		SYSTEM_MAP_FILE="/proc/kallsyms"
 	else
-		SYSTEM_MAP_FILE="/usr/lib/debug/boot/System.map-${KERNEL_VERSION}"
+		echo "System.map file not found for kernel version ${KERNEL_VERSION}"
+		exit 1
 	fi
 fi
 
-
+echo "using System.map file: ${SYSTEM_MAP_FILE}"
 echo "generating configurations for kernel-${KERNEL_VERSION}"
 
 rm -f $OUTPUT_FILE
@@ -51,10 +60,9 @@ make -s -C $FEATURE_TEST_DIR clean KERNELVERSION=$KERNEL_VERSION
 
 run_one_test() {
 	local TEST="$(basename $1 .c)"
-	local OBJ="$TEST.o"
 	local MACRO_NAME="HAVE_$(echo ${TEST} | awk '{print toupper($0)}')"
 	local PREFIX="performing configure test: $MACRO_NAME -"
-	if make -C $FEATURE_TEST_DIR OBJ=$OBJ KERNELVERSION=$KERNEL_VERSION &>/dev/null ; then
+	if make -C $FEATURE_TEST_DIR TEST=$TEST KERNELVERSION=$KERNEL_VERSION &>/dev/null ; then
 		echo "$PREFIX present"
 		echo "#define $MACRO_NAME" >> $OUTPUT_FILE
 	else
@@ -66,7 +74,7 @@ export FEATURE_TEST_DIR
 export KERNEL_VERSION
 export OUTPUT_FILE
 
-ls -1 -q $FEATURE_TEST_FILES | xargs -P "$MAX_THREADS" -d"\n" -n1 -I {} bash -c 'run_one_test {}'
+ls -1 -q $FEATURE_TEST_FILES | xargs -P "$MAX_THREADS" -d"\n" -I {} bash -c 'run_one_test {}'
 
 make -s -C $FEATURE_TEST_DIR clean KERNELVERSION=$KERNEL_VERSION
 

--- a/src/includes.h
+++ b/src/includes.h
@@ -27,5 +27,6 @@
 #include <linux/types.h>
 #include <linux/rwsem.h>
 #include <linux/statfs.h>
+#include <linux/string.h>
 
 #endif

--- a/src/logging.h
+++ b/src/logging.h
@@ -9,16 +9,18 @@
 
 #include "includes.h"
 
+#define DATTO_TAG "datto"
+
 // printing macros
 #define LOG_DEBUG(fmt, args...)                                                \
         do {                                                                   \
                 if (dattobd_debug)                                             \
-                        printk(KERN_DEBUG "datto: " fmt "\n", ##args);         \
+                        printk(KERN_DEBUG DATTO_TAG ": " fmt "\n", ##args);    \
         } while (0)
 
-#define LOG_WARN(fmt, args...) printk(KERN_WARNING "datto: " fmt "\n", ##args)
+#define LOG_WARN(fmt, args...) printk(KERN_WARNING DATTO_TAG ": " fmt "\n", ##args)
 #define LOG_ERROR(error, fmt, args...)                                         \
-        printk(KERN_ERR "datto: " fmt ": %d\n", ##args, error)
+        printk(KERN_ERR DATTO_TAG ": " fmt ": %d\n", ##args, error)
 #define PRINT_BIO(text, bio)                                                   \
         LOG_DEBUG(text ": sect = %llu size = %u",                              \
                   (unsigned long long)bio_sector(bio), bio_size(bio) / 512)

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2025 Datto Inc.
+ */
+
+#include "memory.h"
+
+unsigned long dattobd_get_unmapped_area(struct file *file, unsigned long addr, unsigned long len, unsigned long pgoff, unsigned long flags){
+#if __GET_UNMAPPED_AREA_ADDR
+    unsigned long (*__get_unmapped_area)(struct file *file, unsigned long addr, unsigned long len, unsigned long pgoff, unsigned long flags, vm_flags_t vm_flags) = (__GET_UNMAPPED_AREA_ADDR != 0) ?
+    (unsigned long (*)(struct file *file, unsigned long addr, unsigned long len, unsigned long pgoff, unsigned long flags, vm_flags_t vm_flags)) (__GET_UNMAPPED_AREA_ADDR + (long long)(((void *)kfree) - (void *)KFREE_ADDR)) : NULL;
+
+    return __get_unmapped_area(file, addr, len, pgoff, flags, 0);
+#else
+    return get_unmapped_area(file, addr, len, pgoff, flags);
+#endif
+}

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2025 Datto Inc.
+ */
+
+#ifndef MEMORY_H_
+#define MEMORY_H_
+
+#include "includes.h"
+
+unsigned long dattobd_get_unmapped_area(struct file *file, unsigned long addr, unsigned long len, unsigned long pgoff, unsigned long flags);
+
+#endif /* MEMORY_H_ */
+ 

--- a/src/module_threads.c
+++ b/src/module_threads.c
@@ -102,9 +102,7 @@ int snap_cow_thread(void *data)
         // give this thread the highest priority we are allowed
         set_user_nice(current, MIN_NICE);
 
-        while (!kthread_should_stop() || !bio_queue_empty(bq) ||
-               atomic64_read(&dev->sd_submitted_cnt) !=
-                       atomic64_read(&dev->sd_received_cnt)) { 
+        while (!kthread_should_stop() || !bio_queue_empty(bq) || (atomic64_read(&dev->sd_submitted_cnt) != atomic64_read(&dev->sd_received_cnt) && !is_failed)) { 
                 // wait for a bio to process or a kthread_stop call
                 wait_event_interruptible(bq->event,
                                          kthread_should_stop() ||

--- a/src/mrf.c
+++ b/src/mrf.c
@@ -7,6 +7,7 @@
 #include "mrf.h"
 #include "includes.h"
 #include "snap_device.h"
+#include "hints.h"
 
 #ifdef HAVE_BLK_ALLOC_QUEUE
 //#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
@@ -51,14 +52,18 @@ MRF_RETURN_TYPE (*dattobd_blk_mq_submit_bio)(struct bio*)= (BLK_MQ_SUBMIT_BIO_AD
     (MRF_RETURN_TYPE (*)(struct bio*)) (BLK_MQ_SUBMIT_BIO_ADDR + (long long)(((void*)kfree)-(void*)KFREE_ADDR)): NULL;
 
 MRF_RETURN_TYPE dattobd_snap_null_mrf(struct bio *bio){
+#ifdef HAVE_NONVOID_SUBMIT_BIO_1
+    MRF_RETURN_TYPE exists_to_align_api_only = 0;
     percpu_ref_get(&(dattobd_bio_bi_disk(bio))->queue->q_usage_counter);
+#endif
+
     dattobd_blk_mq_submit_bio(bio);
-    #ifdef HAVE_NONVOID_SUBMIT_BIO_1
-        MRF_RETURN_TYPE exists_to_align_api_only;
-        return exists_to_align_api_only;
-    #else
-        return;
-    #endif
+
+#ifdef HAVE_NONVOID_SUBMIT_BIO_1
+    return exists_to_align_api_only;
+#else
+    return;
+#endif
 }
 
 MRF_RETURN_TYPE dattobd_null_mrf(struct bio *bio)

--- a/src/snap_device.h
+++ b/src/snap_device.h
@@ -24,7 +24,7 @@
 struct tracing_ops {
 	struct block_device_operations *bd_ops;
 	atomic_t refs;
-#ifdef HAVE_BD_HAS_SUBMIT_BIO
+#if defined HAVE_BD_HAS_SUBMIT_BIO || defined HAVE_BDEV_SET_FLAG
         bool has_submit_bio;
 #endif
 };

--- a/src/stack_limits.h
+++ b/src/stack_limits.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/*
+ * Copyright (C) 2025 Datto Inc.
+ */
+
+#ifndef STACK_LIMITS_H_
+#define STACK_LIMITS_H_
+
+#include "logging.h"
+
+// dattobd_bdev_stack_limits(request_queue, bdev, sector_t) -- our wrapper
+
+// queue_limits_stack_bdev(queue_limits, bdev, sector_t, pfx) -- from 6.9
+// bdev_stack_limits(queue_limits, bdev, sector_t) -- from 2.6.33 up to 5.8
+// blk_stack_limits(queue_limits, queue_limits, sector_t) -- from 2.6.31
+
+// dattobd_blk_set_stacking_limits(queue_limits) -- our wrapper
+
+// blk_set_stacking_limits(queue_limits) -- from 3.3
+// blk_set_default_limits(queue_limits) -- from 2.6.31 to 6.1
+
+
+#if defined(HAVE_QUEUE_LIMITS_STACK_BDEV)
+
+// queue_limits_stack_bdev is our top priority, if it is available -- we use it
+
+#define dattobd_bdev_stack_limits(rq, bd, sec) queue_limits_stack_bdev(&(rq)->limits, bdev, sec, DATTO_TAG)
+
+#else
+
+// if queue_limits_stack_bdev is not available, we use bdev_stack_limits, if it is also not available, we emulate it
+
+#if !defined(HAVE_BDEV_STACK_LIMITS)
+
+static int bdev_stack_limits(struct queue_limits *t, struct block_device *bdev, sector_t start){
+    struct request_queue *bq = bdev_get_queue(bdev);
+    start += get_start_sect(bdev);
+    return blk_stack_limits(t, &bq->limits, start << 9);
+}
+
+#endif
+
+#define dattobd_bdev_stack_limits(rq, bd, sec) bdev_stack_limits(&(rq)->limits, bdev, sec)
+
+#endif
+
+#if !defined(HAVE_BLK_SET_STACKING_LIMITS)
+
+#define blk_set_stacking_limits(lim) blk_set_default_limits(lim)
+
+#endif
+
+#endif

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1163,6 +1163,116 @@ error:
         return ret;
 }
 
+static int __try_freeze_bdev(struct block_device* bdev, struct super_block** sb){
+        int ret;
+        struct super_block *origsb = dattobd_get_super(bdev);
+        
+#ifdef HAVE_BDEVNAME  
+        char bdev_name[BDEVNAME_SIZE];      
+        bdevname(bdev, bdev_name);
+#endif     
+        if(origsb){
+                dattobd_drop_super(origsb);
+
+                // freeze and sync block device
+#ifdef HAVE_BDEVNAME                
+                LOG_DEBUG("freezing '%s'", bdev_name);
+#else 
+                LOG_DEBUG("freezing '%pg'", bdev);         
+#endif                
+#ifdef HAVE_FREEZE_SB
+                // #if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
+                *sb = freeze_bdev(bdev);
+                if(!sb){
+#ifdef HAVE_BDEVNAME                          
+                        LOG_ERROR(-EFAULT, "error freezing '%s': null",
+                                  bdev_name);
+#else 
+                        LOG_ERROR(-EFAULT, "error freezing '%pg': null",
+                                  bdev);                                
+#endif 
+                        return -EFAULT;
+                } else if(IS_ERR(sb)){
+#ifdef HAVE_BDEVNAME                          
+                        LOG_ERROR((int)PTR_ERR(sb),
+                                  "error freezing '%s': error", bdev_name);
+#else
+                        LOG_ERROR((int)PTR_ERR(sb),
+                                  "error freezing '%pg': error", bdev);
+#endif
+                        return (int)PTR_ERR(sb);
+                }
+#elif defined HAVE_BDEV_FREEZE
+                ret = bdev_freeze(bdev);
+                if (ret) {
+#ifdef HAVE_BDEVNAME                          
+                        LOG_ERROR(ret, "error freezing '%s'", bdev_name);
+#else
+                        LOG_ERROR(ret, "error freezing '%pg'", bdev);
+#endif                        
+                        return ret;
+                }
+#else
+                ret = freeze_bdev(bdev);
+                if (ret) {
+#ifdef HAVE_BDEVNAME                          
+                        LOG_ERROR(ret, "error freezing '%s'", bdev_name);
+#else
+                        LOG_ERROR(ret, "error freezing '%pg'", bdev);
+#endif                        
+                        return ret;
+                }
+#endif
+        }
+        else {
+#ifdef HAVE_BDEVNAME  
+                LOG_WARN(
+                        "warning: no super found for device '%s', "
+                        "unable to freeze it",
+                        bdev_name);
+#endif
+                return -ENOENT;
+        }
+        
+        return 0;
+}
+
+static int __try_thaw_bdev(struct block_device* bdev, struct super_block* sb){
+        int ret;
+
+#ifdef HAVE_BDEVNAME  
+        char bdev_name[BDEVNAME_SIZE];      
+        bdevname(bdev, bdev_name);
+#endif     
+        // thaw the block device
+#ifdef HAVE_BDEVNAME      
+        LOG_DEBUG("thawing '%s'", bdev_name);
+#else
+        LOG_DEBUG("thawing '%pg'", bdev);
+#endif                
+#ifdef HAVE_THAW_BDEV_INT
+        ret = thaw_bdev(bdev, sb);
+#elif defined HAVE_BDEV_THAW
+        ret = bdev_thaw(bdev);
+#else
+        ret = thaw_bdev(bdev);
+#endif
+        if(ret){
+#ifdef HAVE_BEDVNAME  
+                LOG_ERROR(ret, "error thawing '%s'", bdev_name);
+#else
+                LOG_ERROR(ret, "error thawing '%pg'", bdev);
+#endif
+                // We can't reasonably undo what we've done at this
+                // point, and we've replaced the mrf. pretend we
+                // succeeded so we don't break the block device
+
+                return ret;
+        }
+
+        return 0;
+}
+
 /**
  * __tracer_transition_tracing() - Starts or ends tracing on @bdev depending
  *                                 on whether @dev is defined.  The @bdev is
@@ -1198,69 +1308,20 @@ static int __tracer_transition_tracing(
 #endif
 {
         int ret;
-        struct super_block *origsb = dattobd_get_super(bdev);
-#ifdef HAVE_FREEZE_SB
-        struct super_block *sb = NULL;
-#endif
-
-#ifdef HAVE_BDEVNAME  
-        char bdev_name[BDEVNAME_SIZE];      
-        bdevname(bdev, bdev_name);
-#endif        
+        struct super_block* sb = NULL;
+        bool freezed;
         MAYBE_UNUSED(ret);
-        if(origsb){
-                dattobd_drop_super(origsb);
 
-                // freeze and sync block device
-#ifdef HAVE_BDEVNAME                
-                LOG_DEBUG("freezing '%s'", bdev_name);
-#else 
-                LOG_DEBUG("freezing '%pg'", bdev);         
-#endif                
-#ifdef HAVE_FREEZE_SB
-                // #if LINUX_VERSION_CODE < KERNEL_VERSION(5,11,0)
-                sb = freeze_bdev(bdev);
-                if(!sb){
-#ifdef HAVE_BDEVNAME                          
-                        LOG_ERROR(-EFAULT, "error freezing '%s': null",
-                                  bdev_name);
-#else 
-                        LOG_ERROR(-EFAULT, "error freezing '%pg': null",
-                                  bdev);                                
-#endif 
-                        return -EFAULT;
-                } else if(IS_ERR(sb)){
-#ifdef HAVE_BDEVNAME                          
-                        LOG_ERROR((int)PTR_ERR(sb),
-                                  "error freezing '%s': error", bdev_name);
-#else
-                        LOG_ERROR((int)PTR_ERR(sb),
-                                  "error freezing '%pg': error", bdev);
-#endif
-                        return (int)PTR_ERR(sb);
-                }
-#elif defined HAVE_BDEV_FREEZE
-                ret = bdev_freeze(bdev);
-#else
-                ret = freeze_bdev(bdev);
-                if (ret) {
-#ifdef HAVE_BDEVNAME                          
-                        LOG_ERROR(ret, "error freezing '%s'", bdev_name);
-#else
-                        LOG_ERROR(ret, "error freezing '%pg'", bdev);
-#endif                        
-                        return -ret;
-                }
-#endif
+        // we do not allow freeze to fail during starting tracing
+        // we allow freeze to fail in case of finishing tracing and device is in fail condition
+        ret = __try_freeze_bdev(bdev, &sb);
+        if(ret != 0 && start_tracing){
+                return ret;
         }
-        else {
-#ifdef HAVE_BDEVNAME  
-                LOG_WARN(
-                        "warning: no super found for device '%s', "
-                        "unable to freeze it",
-                        bdev_name);
-#endif
+        if(ret != 0 && !start_tracing && tracer_read_fail_state(dev) == 0){
+                return ret;
         }
+        freezed = (ret == 0);
         smp_wmb();
         if(start_tracing){
                 LOG_DEBUG("starting tracing");
@@ -1307,30 +1368,9 @@ static int __tracer_transition_tracing(
                 *dev_ptr = NULL;
                 smp_wmb();
         }
-        if(origsb){
-                // thaw the block device
-#ifdef HAVE_BDEVNAME      
-                LOG_DEBUG("thawing '%s'", bdev_name);
-#else
-                LOG_DEBUG("thawing '%pg'", bdev);
-#endif                
-#ifdef HAVE_THAW_BDEV_INT
-                ret = thaw_bdev(bdev, sb);
-#elif defined HAVE_BDEV_THAW
-                ret = bdev_thaw(bdev);
-#else
-                ret = thaw_bdev(bdev);
-#endif
-                if(ret){
-#ifdef HAVE_BEDVNAME  
-                        LOG_ERROR(ret, "error thawing '%s'", bdev_name);
-#else
-                        LOG_ERROR(ret, "error thawing '%pg'", bdev);
-#endif
-                        // We can't reasonably undo what we've done at this
-                        // point, and we've replaced the mrf. pretend we
-                        // succeeded so we don't break the block device
-                }
+        if(freezed){
+                ret = __try_thaw_bdev(bdev, sb);
+                // thaws failures are ignored as we can't undo what we have already done
         }
         return 0;
 }

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -24,66 +24,12 @@
 #include "tracing_params.h"
 #include <linux/blk-mq.h>
 #include <linux/version.h>
+#include "stack_limits.h"
 #ifdef HAVE_BLK_ALLOC_QUEUE
 // #if LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0)
 #include <linux/percpu-refcount.h>
 #endif
 
-#if !defined(HAVE_BDEV_STACK_LIMITS) && !defined(HAVE_BLK_SET_DEFAULT_LIMITS)
-// #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,31)
-
-#ifndef min_not_zero
-#define min_not_zero(l, r) ((l) == 0) ? (r) : (((r) == 0) ? (l) : min(l, r))
-#endif
-
-int blk_stack_limits(struct queue_limits *t, struct queue_limits *b,
-                     sector_t offset)
-{
-        t->max_sectors = min_not_zero(t->max_sectors, b->max_sectors);
-        t->max_hw_sectors = min_not_zero(t->max_hw_sectors, b->max_hw_sectors);
-        t->bounce = min_not_zero(t->bounce, b->bounce);
-        t->seg_boundary_mask =
-            min_not_zero(t->seg_boundary_mask, b->seg_boundary_mask);
-        t->max_segments =
-            min_not_zero(t->max_segments, b->max_segments);
-        t->max_segments =
-            min_not_zero(t->max_segments, b->max_segments);
-        t->max_segment_size =
-            min_not_zero(t->max_segment_size, b->max_segment_size);
-        return 0;
-}
-
-static int blk_stack_limits_request_queue(struct request_queue *t, struct request_queue *b,
-                                          sector_t offset)
-{
-        return blk_stack_limits(&t->limits, &b->limits, 0);
-}
-
-static int dattobd_bdev_stack_limits(struct request_queue *t,
-                                     struct block_device *bdev, sector_t start)
-{
-        struct request_queue *bq = bdev_get_queue(bdev);
-        start += get_start_sect(bdev);
-        return blk_stack_limits_request_queue(t, bq, start << 9);
-}
-
-#elif !defined(HAVE_BDEV_STACK_LIMITS)
-// #elif LINUX_VERSION_CODE < KERNEL_VERSION(2,6,32)
-
-static int bdev_stack_limits(struct queue_limits *t, struct block_device *bdev,
-                             sector_t start)
-{
-        struct request_queue *bq = bdev_get_queue(bdev);
-        start += get_start_sect(bdev);
-        return blk_stack_limits(t, &bq->limits, start << 9);
-}
-
-#define dattobd_bdev_stack_limits(queue, bdev, start) \
-        bdev_stack_limits(&(queue)->limits, bdev, start)
-#else
-#define dattobd_bdev_stack_limits(queue, bdev, start) \
-        bdev_stack_limits(&(queue)->limits, bdev, start)
-#endif // # !HAVE_BDEV_STACK_LIMITS) && !HAVE_BLK_SET_DEFAULT_LIMITS
 
 // Helpers to get/set either the make_request_fn or the submit_bio function
 // pointers in a block device.
@@ -96,10 +42,6 @@ static inline BIO_REQUEST_CALLBACK_FN *dattobd_get_bd_fn(
         return bdev->bd_disk->queue->make_request_fn;
 #endif
 }
-
-#ifndef HAVE_BLK_SET_DEFAULT_LIMITS
-#define blk_set_default_limits(ql)
-#endif
 
 #define __tracer_setup_cow_new(dev, bdev, cow_path, size, fallocated_space, \
                                cache_size, uuid, seqid)                     \
@@ -120,9 +62,6 @@ static inline BIO_REQUEST_CALLBACK_FN *dattobd_get_bd_fn(
         __tracer_setup_cow_thread(dev, minor, 0)
 #define __tracer_setup_snap_cow_thread(dev, minor) \
         __tracer_setup_cow_thread(dev, minor, 1)
-#ifndef HAVE_BLK_SET_STACKING_LIMITS
-#define blk_set_stacking_limits(ql) blk_set_default_limits(ql)
-#endif
 
 #ifdef HAVE_BIOSET_NEED_BVECS_FLAG
 #define dattobd_bioset_create(bio_size, bvec_size, scale) \
@@ -981,7 +920,7 @@ static void __tracer_destroy_snap(struct snap_device *dev)
 #ifdef HAVE_BLK_CLEANUP_QUEUE
                 blk_cleanup_queue(dev->sd_queue);
 #else
-#ifndef HAVE_BD_HAS_SUBMIT_BIO
+#if !defined HAVE_GD_OWNS_QUEUE
                 blk_put_queue(dev->sd_queue);
 #endif
 #endif
@@ -1045,8 +984,10 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor,
         // allocate a gendisk struct
         LOG_DEBUG("allocating gendisk");
 
-#ifdef HAVE_BLK_ALLOC_DISK
+#if defined HAVE_BLK_ALLOC_DISK
         dev->sd_gd = blk_alloc_disk(NUMA_NO_NODE);
+#elif defined HAVE_BLK_ALLOC_DISK_2
+        dev->sd_gd = blk_alloc_disk(NULL, NUMA_NO_NODE);
 #else
         dev->sd_gd = alloc_disk(1);
 #endif
@@ -1060,7 +1001,7 @@ static int __tracer_setup_snap(struct snap_device *dev, unsigned int minor,
         LOG_DEBUG("allocating queue");
 #if defined HAVE_BDOPS_SUBMIT_BIO
 
-#if defined HAVE_BLK_ALLOC_DISK
+#if (defined HAVE_BLK_ALLOC_DISK) || (defined HAVE_BLK_ALLOC_DISK_2)
         dev->sd_queue = dev->sd_gd->queue;
 #else // works until 6.9
         dev->sd_queue = blk_alloc_queue(NUMA_NO_NODE);
@@ -1334,8 +1275,10 @@ static int __tracer_transition_tracing(
                 if(bd_ops){
                         bdev->bd_disk->fops= bd_ops;
                 }
-#ifdef HAVE_BD_HAS_SUBMIT_BIO
-        bdev->bd_has_submit_bio=true;
+#if defined HAVE_BD_HAS_SUBMIT_BIO
+                bdev->bd_has_submit_bio=true;
+#elif defined HAVE_BDEV_SET_FLAG
+                bdev_set_flag(bdev, BD_HAS_SUBMIT_BIO);
 #endif
 #endif
                 atomic_inc(&(*dev_ptr)->sd_active);
@@ -1353,7 +1296,12 @@ static int __tracer_transition_tracing(
                         bdev->bd_disk->fops= bd_ops;
                 }
 #ifdef HAVE_BD_HAS_SUBMIT_BIO
-        bdev->bd_has_submit_bio=dev->sd_tracing_ops->has_submit_bio;
+                bdev->bd_has_submit_bio=dev->sd_tracing_ops->has_submit_bio;
+#elif defined HAVE_BDEV_SET_FLAG
+                if(dev->sd_tracing_ops->has_submit_bio)
+                        bdev_set_flag(bdev, BD_HAS_SUBMIT_BIO);
+                else
+                        bdev_clear_flag(bdev, BD_HAS_SUBMIT_BIO);
 #endif
 #endif
                 *dev_ptr = NULL;
@@ -1519,7 +1467,7 @@ static int dattobd_find_orig_mrf(struct block_device *bdev,
         return -EFAULT;
 }
 #else
-int find_orig_bdops(struct block_device *bdev, struct block_device_operations **ops, make_request_fn **mrf, struct tracing_ops** trops, snap_device_array snap_devices){
+static int find_orig_bdops(struct block_device *bdev, struct block_device_operations **ops, make_request_fn **mrf, struct tracing_ops** trops, snap_device_array snap_devices){
         int i;
 	struct snap_device *dev;
 	struct block_device_operations *orig_ops = dattobd_get_bd_ops(bdev);
@@ -1581,6 +1529,8 @@ int tracer_alloc_ops(struct snap_device* dev){
         trops->bd_ops->submit_bio = tracing_fn;
 #ifdef HAVE_BD_HAS_SUBMIT_BIO
         trops->has_submit_bio=dev->sd_base_dev->bdev->bd_has_submit_bio;
+#elif defined HAVE_BDEV_SET_FLAG
+        trops->has_submit_bio = bdev_test_flag(dev->sd_base_dev->bdev, BD_HAS_SUBMIT_BIO);
 #endif
         atomic_set(&trops->refs, 1);
 	dev->sd_tracing_ops = trops;
@@ -1601,31 +1551,33 @@ int tracer_alloc_ops(struct snap_device* dev){
  */
 static int __tracer_should_reset_mrf(const struct snap_device* dev, snap_device_array snap_devices)
 {
-    int i;
-    struct snap_device *cur_dev;
-    struct request_queue *q = bdev_get_queue(dev->sd_base_dev->bdev);
-    MAYBE_UNUSED(q);
+        int i;
+        struct snap_device *cur_dev;
+        struct request_queue *q = bdev_get_queue(dev->sd_base_dev->bdev);
+#ifdef USE_BDOPS_SUBMIT_BIO
+        struct block_device_operations *ops;
+#endif
+        MAYBE_UNUSED(q);
 
 #ifndef USE_BDOPS_SUBMIT_BIO
-    if (GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev->bdev) != tracing_fn) return 0;
+        if (GET_BIO_REQUEST_TRACKING_PTR(dev->sd_base_dev->bdev) != tracing_fn) 
+                return 0;
 #else
-        struct block_device_operations* ops=dattobd_get_bd_ops(dev->sd_base_dev->bdev);
+        ops = dattobd_get_bd_ops(dev->sd_base_dev->bdev);
 #endif
 
     //return 0 if there is another device tracing the same queue as dev.
-    if (snap_devices){
-        tracer_for_each(cur_dev, i){
-            if (!cur_dev || test_bit(UNVERIFIED, &cur_dev->sd_state) 
-                || cur_dev == dev) continue;
+        if (snap_devices){
+                tracer_for_each(cur_dev, i){
+                        if (!cur_dev || test_bit(UNVERIFIED, &cur_dev->sd_state) || cur_dev == dev) continue;
 #ifndef USE_BDOPS_SUBMIT_BIO
-            if (q == bdev_get_queue(cur_dev->sd_base_dev->bdev)) return 0;
+                        if (q == bdev_get_queue(cur_dev->sd_base_dev->bdev)) return 0;
 #else
-                if(ops==dattobd_get_bd_ops(cur_dev->sd_base_dev->bdev)) return 0;
+                        if(ops==dattobd_get_bd_ops(cur_dev->sd_base_dev->bdev)) return 0;
 #endif
+                }
         }
-    }
-
-    return 1;
+        return 1;
 }
 
 /**
@@ -2179,8 +2131,15 @@ void tracer_dattobd_info(const struct snap_device *dev,
         info->cache_size = (dev->sd_cache_size) ?
                                    dev->sd_cache_size :
                                    dattobd_cow_max_memory_default;
+#ifdef HAVE_STRSCPY
         strscpy(info->cow, dev->sd_cow_path, PATH_MAX);
         strscpy(info->bdev, dev->sd_bdev_path, PATH_MAX);
+#elif defined HAVE_STRLCPY
+        strlcpy(info->cow, dev->sd_cow_path, PATH_MAX);
+        strlcpy(info->bdev, dev->sd_bdev_path, PATH_MAX);
+#else
+        #error "No strscpy or strlcpy"
+#endif
 
         if (!test_bit(UNVERIFIED, &dev->sd_state)) {
                 info->falloc_size = dev->sd_cow->file_size;


### PR DESCRIPTION
- Fixed warnings related to DKMS
- Fixed build errors on SLE 15 SP5 and SP6
- Fixed error related to the use of the wrong slab allocation flags
- Fixed endless loop in internal thread in case of block device failure
- Fixed build errors on CentOS 7.3
- Fixed build errors on Oracle UEK
- Fixed kernel hang when freeze fails
- Fixed errors with System.map files on Debian 11
- Fixed build errors on CentOS Stream 9 and 10