### PR TITLE
Fix chained BIO repeat management

### DIFF
--- a/src/bio_helper.h
+++ b/src/bio_helper.h
@@ -82,25 +82,6 @@ void dattobd_bio_set_dev(struct bio *bio, struct block_device *bdev);
 
 void dattobd_bio_copy_dev(struct bio *dst, struct bio *src);
 
-/* don't perform COW operation */
-#ifdef HAVE_ENUM_REQ_OP
-//#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) && LINUX_VERSION_CODE <
-// KERNEL_VERSION(4,10,0)
-/* special case for deb9's 4.9 train
- * Bit 30 conflicts with struct bio's bi_opf opcode bitfield, which occupies the
- * top 3 bits of the member. If we set that bit, it will mutate the operation
- * that the bio is representing. Setting this to 28 puts this in an unused flag
- * for bi_opf (that flag means something in struct request's cmd_flags, but
- * we're not setting that).
- */
-#define __DATTOBD_PASSTHROUGH 28 // set as the last flag bit
-#else
-// set as an unused flag in versions older than 4.8
-// set as an unused opcode bit in kernels newer than 4.9
-#define __DATTOBD_PASSTHROUGH 30
-#endif
-#define DATTOBD_PASSTHROUGH (1ULL << __DATTOBD_PASSTHROUGH)
-
 #ifndef HAVE_SUBMIT_BIO_1
 //#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
 

--- a/src/module_threads.c
+++ b/src/module_threads.c
@@ -194,11 +194,6 @@ int snap_mrf_thread(void *data)
                 // safely dequeue a bio
                 bio = bio_queue_dequeue(bq);
 
-                // submit the original bio to the block IO layer
-                dattobd_bio_op_set_flag(bio, DATTOBD_PASSTHROUGH);
-
-                // blk_qc_t (*)(struct request_queue *, struct bio *)’                 // {aka ‘unsigned int (*)(struct request_queue *, struct bio *)’} but argument is of type ‘struct snap_device *’
-
                 SUBMIT_BIO_REAL(dev,bio);
 #ifdef HAVE_MAKE_REQUEST_FN_INT
                 if (ret)

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1400,28 +1400,23 @@ static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
         snap_device_array snap_devices = get_snap_device_array_nolock();
         MAYBE_UNUSED(ret);
 
-        // The original bio which include (or will include) chained fragments
-        // is managed entirely (all sectors) at once by the COW manager. Hence
-        // we must not care about chained fragments.
-        if (!bio_flagged(bio, BIO_CHAIN))
+        smp_rmb();
+        tracer_for_each(dev, i)
         {
-            smp_rmb();
-            tracer_for_each(dev, i)
+            if (!tracer_is_bio_for_dev(dev, bio)) continue;
+            orig_fn = dev->sd_orig_request_fn;
+            // The original bio which include (or will include) chained fragments
+            // is managed entirely (all sectors) at once by the COW manager. Hence
+            // we must not care about chained fragments.
+            if (tracer_should_trace_bio(dev, bio) && !bio_flagged(bio, BIO_CHAIN))
             {
-                if (!tracer_is_bio_for_dev(dev, bio)) continue;
-                // If we get here, then we know this is a device we're managing
-                // and the current bio belongs to said device.
-                orig_fn = dev->sd_orig_request_fn;
-                if (tracer_should_trace_bio(dev, bio))
-                {
-                    if (test_bit(SNAPSHOT, &dev->sd_state))
-                        ret = snap_trace_bio(dev, bio);
-                    else
-                        ret = inc_trace_bio(dev, bio);
-                    goto out;
-                }
-            } // tracer_for_each(dev, i)
-        }
+                if (test_bit(SNAPSHOT, &dev->sd_state))
+                    ret = snap_trace_bio(dev, bio);
+                else
+                    ret = inc_trace_bio(dev, bio);
+                goto out;
+            }
+        } // tracer_for_each(dev, i)
 
 #ifdef USE_BDOPS_SUBMIT_BIO
         if(unlikely(orig_fn == NULL)){

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1400,29 +1400,28 @@ static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
         snap_device_array snap_devices = get_snap_device_array_nolock();
         MAYBE_UNUSED(ret);
 
-        smp_rmb();
-        tracer_for_each(dev, i)
+        // The original bio which include (or will include) chained fragments
+        // is managed entirely (all sectors) at once by the COW manager. Hence
+        // we must not care about chained fragments.
+        if (!bio_flagged(bio, BIO_CHAIN))
         {
+            smp_rmb();
+            tracer_for_each(dev, i)
+            {
                 if (!tracer_is_bio_for_dev(dev, bio)) continue;
                 // If we get here, then we know this is a device we're managing
                 // and the current bio belongs to said device.
-                orig_fn=dev->sd_orig_request_fn;
-                if (dattobd_bio_op_flagged(bio, DATTOBD_PASSTHROUGH))
+                orig_fn = dev->sd_orig_request_fn;
+                if (tracer_should_trace_bio(dev, bio))
                 {
-                        dattobd_bio_op_clear_flag(bio, DATTOBD_PASSTHROUGH);
+                    if (test_bit(SNAPSHOT, &dev->sd_state))
+                        ret = snap_trace_bio(dev, bio);
+                    else
+                        ret = inc_trace_bio(dev, bio);
+                    goto out;
                 }
-                else
-                {
-                        if (tracer_should_trace_bio(dev, bio))
-                        {
-                                if (test_bit(SNAPSHOT, &dev->sd_state))
-                                        ret = snap_trace_bio(dev, bio);
-                                else
-                                        ret = inc_trace_bio(dev, bio);
-                                goto out;
-                        }
-                } 
-        } // tracer_for_each(dev, i)
+            } // tracer_for_each(dev, i)
+        }
 
 #ifdef USE_BDOPS_SUBMIT_BIO
         if(unlikely(orig_fn == NULL)){
@@ -1444,7 +1443,7 @@ static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
                 }
         }
         else{
-                submit_bio_noacct( bio);
+                submit_bio_noacct(bio);
         }
 #else
         tracer_for_each(dev, i){


### PR DESCRIPTION
Looking at the BIO_CHAIN flag it seems that it appear in the bio after splitting it. Below is presented real life example. First bio with timestamp 78386.890436 is splitted into two: first with 2048 sectors which is managed by the Linux kernel and second with timestamp 78387.427706 which size is equal to 6144 sectors. The second is send to our driver with BIO_CHAIN flag. Next this bio is splitted into two: first with 2048 sectors is managed by kernel and second with timestamp 78387.693920 and size 4096 sectors is send to our driver with BIO_CHAIN flag. So one can see the pattern. First not fragmented bio is managed by our driver so we do not need to care about fragments with BIO_CHAIN flag set.

[78386.890436] datto: REQ_OP_WRITE       <>     BIO flags: BIO_TRACE_COMPLETION BIO_REMAPPED    BLK status: BLK_STS_OK   s: 34069984-34078176 8192
[78387.427706] datto: REQ_OP_WRITE       <>     BIO flags: BIO_CHAIN BIO_TRACE_COMPLETION BIO_REMAPPED  BLK status: BLK_STS_OK   s: 34072032-34078176 6144
[78387.693920] datto: REQ_OP_WRITE       <>     BIO flags: BIO_CHAIN BIO_TRACE_COMPLETION BIO_REMAPPED  BLK status: BLK_STS_OK   s: 34074080-34078176 4096
[78388.159220] datto: REQ_OP_WRITE       <>     BIO flags: BIO_CHAIN BIO_TRACE_COMPLETION BIO_REMAPPED  BLK status: BLK_STS_OK   s: 34076128-34078176 2048

The solution that will solve some issues related with bio looping inside the dattobd include omitting requests with BIO_CHAIN flag set. As described above, the bio which include chained fragments is managed entirely (all sectors) at once in dattobd so we do not care about fragments. If we care then it will make a disaster on some distributions because of too big amount of memory usage.

The DATTOBD_PASSTHROUGH flag has been used to mark already managed bio. When one distinguish if the bio need to be managed by the COW manager using BIO_CHAIN flag then there is no purpose to use this flag. Additionally the system enum type has been used to mark bio with DATTOBD_PASSTHROUGH which seems to be not a good solution.