### PR TITLE
DattoBD 0.12.2 Release

### DIFF
--- a/dist/dattobd.spec
+++ b/dist/dattobd.spec
@@ -136,7 +136,7 @@
 
 
 Name:            dattobd
-Version:         0.12.1
+Version:         0.12.2
 Release:         1%{?dist}
 Summary:         Kernel module and utilities for enabling low-level live backups
 Vendor:          Datto, Inc.

--- a/src/bio_helper.h
+++ b/src/bio_helper.h
@@ -82,25 +82,6 @@ void dattobd_bio_set_dev(struct bio *bio, struct block_device *bdev);
 
 void dattobd_bio_copy_dev(struct bio *dst, struct bio *src);
 
-/* don't perform COW operation */
-#ifdef HAVE_ENUM_REQ_OP
-//#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0) && LINUX_VERSION_CODE <
-// KERNEL_VERSION(4,10,0)
-/* special case for deb9's 4.9 train
- * Bit 30 conflicts with struct bio's bi_opf opcode bitfield, which occupies the
- * top 3 bits of the member. If we set that bit, it will mutate the operation
- * that the bio is representing. Setting this to 28 puts this in an unused flag
- * for bi_opf (that flag means something in struct request's cmd_flags, but
- * we're not setting that).
- */
-#define __DATTOBD_PASSTHROUGH 28 // set as the last flag bit
-#else
-// set as an unused flag in versions older than 4.8
-// set as an unused opcode bit in kernels newer than 4.9
-#define __DATTOBD_PASSTHROUGH 30
-#endif
-#define DATTOBD_PASSTHROUGH (1ULL << __DATTOBD_PASSTHROUGH)
-
 #ifndef HAVE_SUBMIT_BIO_1
 //#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
 

--- a/src/cow_manager.c
+++ b/src/cow_manager.c
@@ -121,23 +121,17 @@ static int __cow_alloc_section(struct cow_manager *cm, unsigned long sect_idx,
  */
 static int __cow_load_section(struct cow_manager *cm, unsigned long sect_idx)
 {
-        int ret, i;
-        int sect_size_bytes = COW_SECTION_SIZE * sizeof(uint64_t);
+        int ret;
 
         ret = __cow_alloc_section(cm, sect_idx, 0);
         if (ret)
                 goto error;
 
-        for (i = 0; i < sect_size_bytes / COW_BLOCK_SIZE; i++) {
-		// int mapping_offset = (COW_BLOCK_SIZE / sizeof(cm->sects[sect_idx].mappings[0])) * i;
-		// int cow_file_offset = COW_BLOCK_SIZE * i;
-
-                ret = file_read(cm->dfilp, cm->dev, cm->sects[sect_idx].mappings,
-                                cm->sect_size * sect_idx * 8 + COW_HEADER_SIZE,
-                                cm->sect_size * 8);
-                if (ret)
-                        goto error;
-        }
+        ret = file_read(cm->dfilp, cm->dev, cm->sects[sect_idx].mappings,
+                        cm->sect_size * sect_idx * 8 + COW_HEADER_SIZE,
+                        cm->sect_size * 8);
+        if (ret)
+                goto error;
 
         return 0;
 
@@ -159,20 +153,15 @@ error:
  */
 static int __cow_write_section(struct cow_manager *cm, unsigned long sect_idx)
 {
-        int i, ret;
-        int sect_size_bytes = COW_SECTION_SIZE * sizeof(uint64_t);
-
-        for (i = 0; i < sect_size_bytes / COW_BLOCK_SIZE; i++) {
-		// int mapping_offset = (COW_BLOCK_SIZE / sizeof(cm->sects[sect_idx].mappings[0])) * i;
-		// int cow_file_offset = COW_BLOCK_SIZE * i;
+        int ret;
 
         ret = file_write(cm->dfilp, cm->dev, cm->sects[sect_idx].mappings,
                          cm->sect_size * sect_idx * 8 + COW_HEADER_SIZE,
                          cm->sect_size * 8);
+
         if (ret) {
                 LOG_ERROR(ret, "error writing cow manager section to file");
                 return ret;
-        }
         }
 
         return 0;
@@ -586,6 +575,7 @@ static unsigned long __cow_calculate_allowed_sects(unsigned long cache_size,
  *                data saved in the supplied COW file.  All cached sections
  *                are marked as having data which will trigger loading from
  *                disk for each data section.
+ * @dev: The &struct snap_device to which COW manager will reference.
  * @path: The path to the COW file.
  * @elements: typically the number of sectors on the block device.
  * @sect_size: The basic unit of size that the &struct cow_manager works with.
@@ -598,8 +588,8 @@ static unsigned long __cow_calculate_allowed_sects(unsigned long cache_size,
  * * 0 - success
  * * !0 - errno indicating the error
  */
-int cow_reload(const char *path, uint64_t elements, unsigned long sect_size,
-               unsigned long cache_size, int index_only,
+int cow_reload(struct snap_device* dev, const char *path, uint64_t elements,
+               unsigned long sect_size, unsigned long cache_size, int index_only,
                struct cow_manager **cm_out)
 {
         int ret;
@@ -628,6 +618,7 @@ int cow_reload(const char *path, uint64_t elements, unsigned long sect_size,
                 __cow_calculate_allowed_sects(cache_size, cm->total_sects);
         cm->data_offset = COW_HEADER_SIZE + (cm->total_sects * (sect_size * sizeof(uint64_t)));
         cm->auto_expand = NULL;
+        cm->dev = dev;
 
         ret = __cow_open_header(cm, index_only, 1);
         if (ret)

--- a/src/cow_manager.h
+++ b/src/cow_manager.h
@@ -87,8 +87,8 @@ int cow_sync_and_close(struct cow_manager *cm);
 
 int cow_reopen(struct cow_manager *cm, const char *pathname);
 
-int cow_reload(const char *path, uint64_t elements, unsigned long sect_size,
-               unsigned long cache_size, int index_only,
+int cow_reload(struct snap_device* dev, const char *path, uint64_t elements,
+               unsigned long sect_size, unsigned long cache_size, int index_only,
                struct cow_manager **cm_out);
 
 int cow_init(struct snap_device *dev, const char *path, uint64_t elements, unsigned long sect_size,

--- a/src/dattobd.h
+++ b/src/dattobd.h
@@ -15,7 +15,7 @@
 #include <linux/limits.h>
 #include <linux/types.h>
 
-#define DATTOBD_VERSION "0.12.1"
+#define DATTOBD_VERSION "0.12.2"
 #define DATTO_IOCTL_MAGIC 0x91
 
 struct setup_params {

--- a/src/module_threads.c
+++ b/src/module_threads.c
@@ -194,11 +194,6 @@ int snap_mrf_thread(void *data)
                 // safely dequeue a bio
                 bio = bio_queue_dequeue(bq);
 
-                // submit the original bio to the block IO layer
-                dattobd_bio_op_set_flag(bio, DATTOBD_PASSTHROUGH);
-
-                // blk_qc_t (*)(struct request_queue *, struct bio *)’                 // {aka ‘unsigned int (*)(struct request_queue *, struct bio *)’} but argument is of type ‘struct snap_device *’
-
                 SUBMIT_BIO_REAL(dev,bio);
 #ifdef HAVE_MAKE_REQUEST_FN_INT
                 if (ret)

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -1409,7 +1409,7 @@ static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
                 orig_fn=dev->sd_orig_request_fn;
 
                 // Splited BIO fragments are resubmitted by MRF thread.
-                // COW manager have already written all data from original BIO
+                // COW manager has already written all data from original BIO.
                 // Hence, no need to send same data to COW manager again.
                 if (current != dev->sd_mrf_thread)
                 {

--- a/src/tracer.c
+++ b/src/tracer.c
@@ -597,7 +597,7 @@ static int __tracer_setup_cow(struct snap_device *dev,
                 } else {
                         // reload the cow manager
                         LOG_DEBUG("reloading cow manager");
-                        ret = cow_reload(cow_path, SECTOR_TO_BLOCK(size),
+                        ret = cow_reload(dev, cow_path, SECTOR_TO_BLOCK(size),
                                          COW_SECTION_SIZE, dev->sd_cache_size,
                                          (open_method == 2), &dev->sd_cow);
                         if (ret)
@@ -1407,11 +1407,11 @@ static MRF_RETURN_TYPE tracing_fn(struct request_queue *q, struct bio *bio)
                 // If we get here, then we know this is a device we're managing
                 // and the current bio belongs to said device.
                 orig_fn=dev->sd_orig_request_fn;
-                if (dattobd_bio_op_flagged(bio, DATTOBD_PASSTHROUGH))
-                {
-                        dattobd_bio_op_clear_flag(bio, DATTOBD_PASSTHROUGH);
-                }
-                else
+
+                // Splited BIO fragments are resubmitted by MRF thread.
+                // COW manager have already written all data from original BIO
+                // Hence, no need to send same data to COW manager again.
+                if (current != dev->sd_mrf_thread)
                 {
                         if (tracer_should_trace_bio(dev, bio))
                         {


### PR DESCRIPTION
Release notes:
- Splited BIO fragments are identified and don't enter COW manager
- Fixed cow_init issue with no snapshot device reference
- Some minor changes